### PR TITLE
Proofread docs, remove links from index.rst

### DIFF
--- a/source/allocators.md
+++ b/source/allocators.md
@@ -165,7 +165,7 @@ slab_map(struct slab_arena *arena)
 <a name="slab_unmap"></a>
 
 Of course, we can also return one to an **arena**. In this case, we push
- it into the previously mentioned list of returned **slabs** to get it back
+it into the previously mentioned list of returned **slabs** to get it back
 faster next time.
 
 ```c

--- a/source/allocators.md
+++ b/source/allocators.md
@@ -165,7 +165,7 @@ slab_map(struct slab_arena *arena)
 <a name="slab_unmap"></a>
 
 Of course, we can also return one to an **arena**. In this case, we push
-it into previously mentioned list of returned **slabs** to get it back
+ it into the previously mentioned list of returned **slabs** to get it back
 faster next time.
 
 ```c

--- a/source/allocators.md
+++ b/source/allocators.md
@@ -119,11 +119,11 @@ slab_arena_create(struct slab_arena *arena, struct quota *quota,
 
 <a name="slab_map"></a>
 
-Most importantly, arena allows us to map a **slab**. First we check the
+Most importantly, arena allows us to map a **slab**. First, we check the
 list of returned **slabs**, called **arena** cache (not
 **slab cache**), which contains previously used and now emptied slabs.
 If there are no such **slabs**, we confirm that **quota** limit is
-fullfilled and then either take **slab** from the **preallocated** area
+fulfilled and then either take **slab** from the **preallocated** area
 or allocate it.
 
 ```c
@@ -164,7 +164,7 @@ slab_map(struct slab_arena *arena)
 
 <a name="slab_unmap"></a>
 
-Of course we can also return one to an **arena**. In this case we push
+Of course, we can also return one to an **arena**. In this case, we push
 it into previously mentioned list of returned **slabs** to get it back
 faster next time.
 
@@ -187,9 +187,9 @@ Slab cache allows us to get a piece of **arena slab** with the size
 close to needed. It implements a buddy system, which means that we get
 **slabs** of the size that is a power of 2 (**arena slab**, which size
 is also power of 2, is being divided until we get the chunk of the
-appropiate size, or we just get corresponding already available chunk),
-and then, when it is freed, we look for it's **neighbour (buddy)** to
-**merge** them, if neighbour is also free, to avoid **fragmentation**.
+appropriate size, or we just get corresponding already available chunk),
+and then, when it is freed, we look for its **neighbour (buddy)** to
+**merge** them, if the neighbour is also free, to avoid **fragmentation**.
 
 ### Slab & slab cache definition
 
@@ -298,7 +298,7 @@ Most importantly, it allows us to acquire a **slab** of needed
 starting from the given **order**. We can use slabs of higher
 **order**. In case nothing is found, we are trying to get a new
 **arena slab** using previously described **arena** method
-[slab_map](#slab_map). We preprocess it and add to the corresponding
+[slab_map](#slab_map). We preprocess it and add it to the corresponding
 lists. Then we are splitting the **slab** if the **order** doesn't
 match exactly.
 
@@ -407,14 +407,14 @@ slab_put_large(struct slab_cache *cache, struct slab *slab)
 ```
 
 When the normal **slab** is being emptied, it is processed in a more
-specific way, as mentioned above. We get it's **buddy** (neighbour
+specific way, as mentioned above. We get its **buddy** (neighbour
 **slab** of the same size, which complements current **slab** to the
 **slab** of the next **order**). if **buddy** is not in use and is not
 split into smaller parts, we **merge** them and get free **slab** of
 the next **order**, thus avoiding fragmentation. If we get an
-**arena slab** as the result, we return it to **arena** using it's
+**arena slab** as the result, we return it to **arena** using its
 method [slab_unmap](#slab_unmap) in case there is already an
-**arena slab** in **cache**. Otherwise we leave it in **slab cache** to
+**arena slab** in **cache**. Otherwise, we leave it in **slab cache** to
 avoid extra moves.
 
 ```c
@@ -474,8 +474,8 @@ slab_put_with_order(struct slab_cache *cache, struct slab *slab)
 Mempool is used to allocate small objects through splitting
 **slab cache ordered slabs** into pieces of the equal size. This is
 extremely helpful for vast amounts of fast allocations. On creation we
-need to specify object size for a **memory pool**. Thus possible object
-count is calculated and we get the **memory pool** with int64_t aligned
+need to specify object size for a **memory pool**. Thus, the possible object
+count is calculated, and we get the **memory pool** with int64_t aligned
 **offset** ready for allocations. **Mempool** works with **slab** wrap
 called **mslab**, which is needed to cut it in pieces.
 
@@ -637,14 +637,14 @@ mslab_create(struct mslab *slab, struct mempool *pool)
 Most importantly, mempool allows to allocate memory for a small object.
 This allocation is the most frequent in **tarantool**. Memory piece is
 being given solely based on the provided mempool. The first problem is
-to find suitable **slab**. If there is an appropiate slab, already
+to find a suitable **slab**. If there is an appropriate slab, already
 acquired from **slab cache** and still available, it will be used.
-Otherwise we might get totally free **cached slab** not yet returned to
+Otherwise, we might get totally free **cached slab** not yet returned to the
 arena. In case there are no such slabs, we will try to perform possibly
 heavier operation, trying to get a slab from the **slab cache** through
-it's [slab_get_with_order](#slab_get_with_order) method. As the last
+its [slab_get_with_order](#slab_get_with_order) method. As the last
 resort we are trying to get a **cold slab**, the type of **slab** which
-is mostly fillled, but has one freed block.
+is mostly filled, but has one freed block.
 This **slab** is being added to **hot** list, and then, finally, we are
 acquiring direct pointer through *mslab_alloc*, using **mslab** offset,
 shifting as we allocate new pieces.
@@ -716,7 +716,7 @@ There is a possibility to free memory from each allocated small object.
 Each **mslab** has **free_list** -- list of emptied chunks. It is being
 updated according to the new emptied area pointer. Then we decide where
 to place processed **mslab**: it will be either **hot** one, **cold**
-one, or **spare** one, depenging on the new free chunks amount.
+one, or **spare** one, depending on the new free chunks amount.
 
 ```c
 void
@@ -777,7 +777,7 @@ mslab_free(struct mempool *pool, struct mslab *slab, void *ptr)
 ## Small
 
 On the top of **allocators**, listed above, we have one more -- the one
-actually used to allocate tuples. Basically, here we are trying to find
+actually used to allocate tuples. Basically, here we are trying to find a
 suitable **mempool** to perform [mempool_alloc](#mempool_alloc) on it.
 Small system introduces **stepped** and **factored** pools to fit
 different **allocation** sizes. There is an array of **stepped** pools,
@@ -787,7 +787,7 @@ bytes and differ by predefined *STEP_SIZE*. There are also **factored**
 pools, which are intended to be used for bigger objects. They are
 called **factored** as far as each of them can contain objects from
 size *sz* to size *alloc_factor * sz*, where *alloc_factor* may be
-adjusted by user. **Factored** pools are only being created for given
+adjusted by the user. **Factored** pools are only being created for a given
 size if needed, and their amount is limited.
 
 ### Factor pool & small allocator definitions
@@ -930,25 +930,25 @@ small_alloc_create(struct small_alloc *alloc, struct slab_cache *cache,
 <a name="smalloc"></a>
 
 Most importantly, **small allocator** allows us to allocate memory for
-an object of given size. Here we start from **garbage collection**.
+an object of a given size. Here we start with **garbage collection**.
 **Factored pools** are being created when needed on allocation. First
 we start with garbage collection. This means we actually deallocate
 previously pushed to queues normal and large allocations, using
 *mempool_free* with [mslab_free](#mslab_free) under the hood and
 [slab_put_large](#slab_put_large) respectively.
 Next thing to do is to decide if we can use **stepped pool** for
-allocation or we need to use **factored pool** based on given object
-size. To calculated which **stepped pool** is needed, we divide size
-by *STEP_SIZE* using bit shift and subtract predefined smallest
-possible size (alreay divided by *STEP_SIZE*), as far as sizes don't
-start from zero. Thus we either get needed pool and may proceed to
-[mempool_alloc](#mempool_alloc) or understand, that size is to big
-for **stepped pools**. Therefore we will try to find big enough
+allocation, or we need to use **factored pool** based on the given object
+size. To calculate which **stepped pool** is needed, we divide size
+by *STEP_SIZE* using bit shift and subtract predefined the smallest
+possible size (already divided by *STEP_SIZE*), as far as sizes don't
+start from zero. Thus, we either get the needed pool and may proceed to
+[mempool_alloc](#mempool_alloc) or understand that size is too big
+for **stepped pools**. Therefore, we will try to find a big enough
 **factored pool**. If there is nothing big enough for given **size**,
 we will try to use [slab_get_large](#slab_get_large) directly.
-Otherwise we will either proceed to [mempool_alloc](#mempool_alloc) or
+Otherwise, we will either proceed to [mempool_alloc](#mempool_alloc) or
 try creating smaller **factored pool** (if relevant). If we are not
-succeeding with smaller **factored pool**, we will need to use
+succeeding with a smaller **factored pool**, we will need to use an
 imperfect one. Anyway, finally, we are coming with our pool to
 [mempool_alloc](#mempool_alloc) (except the case where we had to try
 [slab_get_large](#slab_get_large) instead).
@@ -1028,7 +1028,7 @@ function, used as the allocation function for **memtx index** needs by
 **matras**, which works in pair with *memtx_index_extent_reserve*.
 *memtx_index_extent_reserve* is being called when we are going to
 **build** or **rebuild index** to make sure that we have enough
-**reserved extents**. Otherwise *memtx_index_extent_reserve* tries to
+**reserved extents**. Otherwise, *memtx_index_extent_reserve* tries to
 allocate **extents** until we get the given number and aborts if it
 can't be done. This allows us to stick to consistency and abort the
 operation before it is too late.

--- a/source/fiber.rst
+++ b/source/fiber.rst
@@ -257,7 +257,7 @@ Fibers do not start execution automatically, we have to call
         ev_run(loop(), 0);
 
 Here once the fiber is created we kick it to execute. This is done
-inside ``fiber_call_impl` which uses ``core_transfer``
+inside ``fiber_call_impl`` which uses ``core_transfer``
 routine to jump into ``fiber_loop`` and invoke ``run_script_f``
 inside.
 

--- a/source/fiber.rst
+++ b/source/fiber.rst
@@ -7,7 +7,7 @@ Introduction
 ------------
 
 Tarantool uses cooperative multitasking via that named fibers.
-They are similar to well known threads except they are not running
+They are similar to well-known threads except they are not running
 simultaneously but must be scheduled explicitly.
 
 Fibers are coupled into cords (in turn the cords are real threads,
@@ -15,7 +15,7 @@ thus fibers inside a cord are executing in a sequent way while several
 cords may run simultaneously).
 
 When we create a fiber we provide a function to be invoked upon fiber's
-start, lets call it a fiber function to distinguish from other
+start, let's call it a fiber function to distinguish from other
 service routines.
 
 Event library
@@ -24,7 +24,7 @@ Event library
 The heart of Tarantool fibers schedule is ``libev`` library. As its
 name implies the library provides an loop which get interrupted when an
 event arrive. We won't jump into internals of ``libev`` but provide
-only a few code snippets to draw a basic workflow
+only a few code snippets to draw a basic workflow.
 
 .. code-block:: c
 
@@ -37,19 +37,19 @@ only a few code snippets to draw a basic workflow
         }
     }
 
-The ``backend_poll`` invokes low level service call (such as ``epoll`` or
-``select`` depending on operating system, please see their man pages)
-to fetch events. Evens are explicitly passed to queue via API ``libev``
+The ``backend_poll`` invokes low-level service call (such as ``epoll`` or
+``select`` depending on the operating system, please see their man pages)
+to fetch events. Evens are explicitly passed to a queue via API ``libev``
 provides to programmers. The service call supports ``waittime`` timeout,
-so if no events available a new wait iteration started or polling to be precise.
-The typical minimal ``waittime`` is 1 millisecond.
+so if no events are available a new wait iteration is started or polling to be
+precise. The typical minimal ``waittime`` is 1 millisecond.
 
 The ``EV_INVOKE_PENDING`` fetches events to process and runs associated
 callbacks for this iteration. Once callbacks are finished a new iteration
 begins.
 
-Pushing new event into the queue is provided by ``ev_feed_event`` call
-and Tarantool use it under the hood.
+Pushing a new event into the queue is provided by ``ev_feed_event`` call
+and Tarantool uses it under the hood.
 
 Fibers engine overview
 ----------------------
@@ -65,11 +65,11 @@ The main cord defined as
     #define loop()    (cord()->loop)
 
 Note the ``cord()``, ``fiber()`` and ``loop()`` helper macros.
-They are used frequently to access currently executing cord,
+They are used frequently to access the currently executing cord,
 fiber and event loop.
 
 The cord structure is the following (note that we are posting stripped
-versions of structures in sake of simplicity)
+versions of structures for the sake of simplicity)
 
 .. code-block:: c
 
@@ -133,7 +133,7 @@ The fiber structure is the following
         int             f_ret;
     }
 
-When Tarantool starts it creates the main cord
+When Tarantool starts it creates the main cord:
 
 .. code-block:: c
 
@@ -144,10 +144,10 @@ When Tarantool starts it creates the main cord
             main_cord.loop = ev_default_loop();
             cord_create(&main_cord, "main");
 
-Don't pay attention on ``fiber_cxx_invoke`` for now, it is just
+Don't pay attention to ``fiber_cxx_invoke`` for now, it is just
 a wrapper to run a fiber function.
 
-The cord creation is the following
+The cord creation is the following:
 
 .. code-block:: c
 
@@ -172,11 +172,11 @@ When the cord is created the **scheduler fiber** ``cord->sched``
 becomes its primary one. Think of it as a main fiber which will
 switch all other fibers in this cord.
 
-Note that here we setup ``cord()`` macro to point to ``main_cord``,
+Note that here we setup ``cord()`` macro to point to ``main_cord``;
 thus ``fiber()`` will point to main cord scheduler fiber and
 ``loop()`` will be ``ev_default_loop``.
 
-Abstract description is not very useful so lets look how Tarantool
+An abstract description is not very useful so let's look at how Tarantool
 boots in interactive console mode (the mode is not really important
 here but rather a call graph).
 
@@ -195,22 +195,22 @@ here but rather a call graph).
 
 Here we create a new fiber to run ``run_script_f`` fiber
 function. ``fiber_new`` allocates a new fiber instance
-(actually there is a fiber cache so that if a previous fiber
+(actually, there is a fiber cache so that if a previous fiber
 already finished its work and exited we can reuse it without
 calling ``mempool_alloc`` but this is just an optimization
 for speed sake), then we chain it into the main cord's
 ``alive`` list and register in fiber IDs pool.
 
-One of the clue here is ``coro_create`` call, where "coro"
+One of the clues here is ``coro_create`` call, where "coro"
 stands for "coroutine". Coroutines are implemented via ``coro``
 library. On Linux it simply handles hardware context to reload
-registers and jump into desired function. More precisely the heart of "coro"
-library is ``coro_transfer(&from, &to)`` routine which remembers current
-point of execution (``from``) and transfer flow to the new instruction
+registers and jump into the desired function. More precisely the heart of
+"coro" library is ``coro_transfer(&from, &to)`` routine which remembers current
+point of execution (``from``) and transfers flow to the new instruction
 pointer provided (``to`` which is created during ``coro_create``).
 
 Note that the fiber function is wrapped by ``fiber_loop``.
-This is because the fiber function itself may not call scheduler
+This is because the fiber function itself may not call the scheduler
 explicitly but we have to pass execution to others fibers, thus
 we simply call fiber function manually inside ``fiber_loop``
 and reschedule then.
@@ -244,7 +244,7 @@ memory again) via ``fiber_recycle`` and finally we move execution
 flow back to the scheduler fiber via ``fiber_yield``.
 
 Fibers do not start execution automatically, we have to call
-``fiber_start``. Thus back to Tarantool startup
+``fiber_start``. Thus back to Tarantool startup:
 
 .. code-block:: c
 
@@ -261,8 +261,8 @@ inside ``fiber_call_impl`` which uses ``core_transfer``
 routine to jump into ``fiber_loop`` and invoke ``run_script_f``
 inside.
 
-The ``run_script_f`` shows a good example how to give execution
-back to scheduler fiber and continue
+The ``run_script_f`` shows a good example of how to give execution
+back to scheduler fiber and continue:
 
 .. code-block:: c
 
@@ -285,8 +285,8 @@ to the scheduler fiber
                 caller->caller = &cord->sched;
                 coro_transfer(&caller->ctx, &callee->ctx);
 
-Once ``coro`` jumped into scheduler fiber another fiber is
-chosen to execute. At some moment scheduler return execution
+Once ``coro`` jumped into the scheduler fiber another fiber is
+chosen to execute. At some moment scheduler returns execution
 to the point after ``fiber_sleep(0.0)`` and we step up back
 to ``tarantool_lua_run_script`` and run main event loop
 ``ev_run(loop(), 0)``. Now all future execution will be driven
@@ -298,7 +298,7 @@ manual but we mention a few just to complete this introduction:
  - ``cord_create`` to create a new cord;
  - ``fiber_new`` to create a new fiber but not run it;
  - ``fiber_start`` to execute a fiber immediately;
- - ``fiber_cancel`` to cancel execution of a fiber;
+ - ``fiber_cancel`` to cancel the execution of a fiber;
  - ``fiber_join`` to wait for a cancelled fiber;
  - ``fiber_yield`` to switch execution to another fiber,
    the execution will back to the point after this call later.
@@ -306,10 +306,10 @@ manual but we mention a few just to complete this introduction:
    on this fiber, until then it won't be scheduled. This is the key
    function of fibers switch;
  - ``fiber_sleep`` to sleep some time giving execution
-   to another fibers;
+   to another fiber;
  - ``fiber_yield_timeout`` to give execution to another
    fibers with some timeout value;
- - ``fiber_reschedule`` give execution to another fibers.
+ - ``fiber_reschedule`` give execution to another fiber.
    In contrast with plain ``fiber_yield`` we are moving self
    to the end of cord's ``ready`` list. We will grab execution
    back when all fibers already waiting for execution are
@@ -318,12 +318,13 @@ manual but we mention a few just to complete this introduction:
 Fiber's scheduling
 ------------------
 
-Due to cooperative multitasking we have to provide scheduling points explicitly.
-Still from API point of view it is not very clear how exactly fibers are chosen
-for execution and how they are managed on low level. Here we explain some details.
+Due to cooperative multitasking, we have to provide scheduling points
+explicitly. Still from API point of view, it is not very clear how exactly
+fibers are chosen for execution and how they are managed on a low level. Here
+we explain some details.
 
-Each cord has a statically allocated scheduler fiber. Lets look again into a cord
-and fiber structure and put comments on their linking.
+Each cord has a statically allocated scheduler fiber. Let's look again into a
+cord and fiber structure and put comments on their linking.
 
 .. code-block:: c
 
@@ -365,7 +366,7 @@ and fiber structure and put comments on their linking.
         struct rlist        wake;
     }
 
-Lets put transition schematics immediately so the next explanation will be pictured.
+Let's put transition schematics immediately so the next explanation will be pictured.
 
 .. code-block:: text
 
@@ -420,15 +421,15 @@ complete structure. So when cord is created the ``sched`` is initialized manuall
     }
 
 The ``cord->sched`` does not even have a separate stack because the cord and
-its scheduler are executed inside a main thread itself (actually cord may be
-running inside separate thread as well but still doesn't require own stack
+its scheduler are executed inside the main thread itself (actually cord may be
+running inside separate thread as well but still doesn't require its own stack
 to have).
 
 Binding to ``libev`` is done via ``ev_async_init`` and ``ev_idle_init`` calls.
 
-When that named *idle* state comes in (ie the state where we have no event to handle)
+When that named *idle* state comes in (i.e. the state where we have no event to handle)
 then ``fiber_schedule_idle`` is executed. Currently ``fiber_schedule_idle`` does simply
-nothing and rather reserved for future use.
+nothing and is rather reserved for future use.
 
 In turn ``fiber_schedule_wakeup`` bound to ``ev_async_init``. The asynchronous event
 is bound to a special pipe inside ``libev`` so that such events will have maximal
@@ -436,7 +437,7 @@ priority to deliver. Thus when we trigger ``fiber_schedule_wakeup`` it will be h
 with high priority (not immediately though, event feeding means that we've put it into
 a pipe).
 
-Now lets create a new fiber and run it.
+Now let's create a new fiber and run it.
 
 .. code-block:: c
 
@@ -468,9 +469,10 @@ Now lets create a new fiber and run it.
         // New fibers are prepends the @cord->alive list
     }
 
-Upon a new fiber creation we put it to the head of ``cord->alive`` list via
+Upon a new fiber creation, we put it to the head of ``cord->alive`` list via
 ``fiber->link`` list. It is not running yet we have to give it an execution
-slot explicitly via ``fiber_start`` call (which just a wrapper over ``fiber_call``).
+slot explicitly via ``fiber_start`` call (which is just a wrapper over
+``fiber_call``).
 
 .. code-block:: c
 
@@ -513,7 +515,7 @@ The fiber to execute remembers its caller via ``fiber::caller``. And the
 We set the currently running fiber to ``cord->fiber`` and jump into fiber's execution.
 Note at this moment the fiber is sitting in ``cord->alive`` list. Same time we drop
 ``FIBER_IS_READY`` flag from us since we're already executing and if we're trying
-to wakeup self we will exit early.
+to wake up self we will exit early.
 
 Once we start executing we could either
 
@@ -552,7 +554,7 @@ When fiber is exiting the execution flow returns to ``fiber_loop``.
             }
 
             //
-            // Remove penging wakeups
+            // Remove pending wakeups
             rlist_del(&fiber->state);
 
             //
@@ -567,11 +569,11 @@ When fiber is exiting the execution flow returns to ``fiber_loop``.
         }
     }
 
-In simple scenario we just move this fiber to the ``cord->dead`` list via
+In a simple scenario we just move this fiber to the ``cord->dead`` list via
 ``fiber_recycle`` and reuse it later when we need to create a new fiber.
 
 An interesting scenario is where there are some waiters. *Waiters* mean that there
-are some fibers which waits for our exit. In terms of API it means that another fiber
+are some fibers which wait for our exit. In terms of API it means that another fiber
 has called ``fiber_join_timeout``.
 
 .. code-block:: c
@@ -608,14 +610,14 @@ has called ``fiber_join_timeout``.
         fiber_recycle(fiber);
     }
 
-The key moment here is that target fiber which we are waiting to exit
+The key moment here is that the target fiber which we are waiting to exit
 puts us to own ``fiber->wake`` list. Thus we become a *waiting* fiber
-and calls ``fiber_yield`` all the time (we don't consider a case where
+and call ``fiber_yield`` all the time (we don't consider a case where
 we wait with timeout because the only difference is that we can exit
 earlier due to timeout expiration) skipping our execution slot giving
 control back to the scheduler. The target fiber will wake us upon its
-completion. It is done via tail of ``fiber_loop`` call. Lets repeat
-this moment
+completion. It is done via tail of ``fiber_loop`` call. Let's repeat
+this moment:
 
 .. code-block:: c
 
@@ -641,7 +643,7 @@ this moment
         }
     }
 
-Thus here is an interesting transition. Lets assume we've a few fibers:
+Thus here is an interesting transition. Let's assume we've a few fibers:
 ``fiber-1`` and ``fiber-2``. Both are not running just hanging in ``cord->alive``
 list.
 
@@ -654,10 +656,11 @@ list.
 Then we need the ``fiber-2`` to wait until ``fiber-1`` is finished. So we mark
 ``fiber-1`` via ``fiber_set_joinable(fiber-1, true)`` and then start waiting
 for it to complete via ``fiber_join(fiber-1)`` call. The ``fiber_join`` simply
-gives execution slot to the scheduler which runs ``fiber-1``. Once ``fiber-1``
-finishes it notifies scheduler to wake up waiting ``fiber-2`` and enters into
-``fiber_yield``. Then scheduler finally gives execution back to ``fiber-2`` which
-in turn rips ``fiber-1`` via ``fiber_recycle`` and continue own execution.
+gives an execution slot to the scheduler which runs ``fiber-1``. Once
+``fiber-1`` finishes it notifies scheduler to wake up waiting ``fiber-2`` and
+enters into ``fiber_yield``. Then the scheduler finally gives execution back
+to ``fiber-2`` which in turn rips ``fiber-1`` via ``fiber_recycle`` and
+continues its own execution.
 
 Here is how this transition goes.
 
@@ -693,7 +696,7 @@ Here is how this transition goes.
 Fiber yield
 ~~~~~~~~~~~
 
-Now lets look into ``fiber_yield`` implementation.
+Now let's look into ``fiber_yield`` implementation.
 
 .. code-block:: c
 
@@ -714,7 +717,7 @@ The ``caller`` is our fiber which calls ``fiber_yield`` and the fiber to
 switch execution to is our ``fiber->caller`` member.
 
 Initially this ``fiber->caller`` is set in ``fiber_call`` routine. In
-other word when fiber is executed for first time because there must
+other words when fiber is executed for first time because there must
 be some parent fiber which created and run the new fibers.
 
 .. code-block:: text
@@ -734,7 +737,7 @@ be some parent fiber which created and run the new fibers.
             `<- fiber_1->caller
 
 So using ``caller`` value we switch execution to ``fiber_1`` because
-it is a parent of ``fiber_2`` but this is a one shot action. Same time
+it is a parent of ``fiber_2`` but this is a one-shot action. Same time
 we reset ``fiber_1`` caller to the main scheduler ``cord->sched`` so the
 next time these fibers will be running ``fiber_yield`` the execution will
 be transferred to the scheduler.
@@ -742,7 +745,7 @@ be transferred to the scheduler.
 Fiber wakeup
 ~~~~~~~~~~~~
 
-Once a fiber suspended own execution slot to the caller (either a parent
+Once a fiber suspended its own execution slot to the caller (either a parent
 fiber or the scheduler) it simply sits in memory doing nothing and someone
 has to wake it up and run again. The parent (or any other fiber) has to call
 ``fiber_wakeup`` with this suspended fiber as an argument.
@@ -778,7 +781,7 @@ depend on transactions order and WAL processing.
 
 Note that calling ``fiber_wakeup`` does not cause ``fiber_schedule_wakeup``
 to run immediately. The caller should give execution back to the scheduler
-explicitly (via same ``fiber_yield`` for example).
+explicitly (via the same ``fiber_yield`` for example).
 
 Finally the ``fiber_schedule_wakeup`` takes place
 
@@ -833,7 +836,7 @@ make each fiber be a parent of the next one. The last entry in the list
 use main scheduler ``cord()->sched`` as a parent.
 
 And finally we run first queued fiber. When it call ``fiber_yield`` then
-the next previously queued fiber will be executed. Lets try to draw the
+the next previously queued fiber will be executed. Let's try to draw the
 transition.
 
 Assume there is 3 fibers which creates each other in sequence.
@@ -851,7 +854,7 @@ Assume there is 3 fibers which creates each other in sequence.
            `- fiber-3 <~~~~|~~ running
                 `- caller -+
 
-Lets presume the ``fiber-3`` is running and calls ``fiber_yield``, then
+Let's presume the ``fiber-3`` is running and calls ``fiber_yield``, then
 we make its parent be ``cord->sched`` and transfer execution to ``fiber-2``.
 
 .. code-block:: text
@@ -934,7 +937,7 @@ slot and reorders ``caller`` chain so that ``fiber-2`` starts running but its
 ``caller`` now points to ``fiber-3``, and when ``fiber-2`` calls ``fiber_yield()``
 the next target to execute is ``fiber-3``.
 
-When ``fiber-3`` make own ``fiber_yield()`` the transition goes back to the
+When ``fiber-3`` make its own ``fiber_yield()`` the transition goes back to the
 main scheduler and ``caller`` for all three fibers point to main
 scheduler again.
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -3,7 +3,6 @@ Tarantool internals
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
 
    fiber
    replication
@@ -12,11 +11,3 @@ Tarantool internals
    wal
    wal-fmt
    allocators
-
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`

--- a/source/replication.rst
+++ b/source/replication.rst
@@ -230,8 +230,8 @@ trigger. We won't be jumping into it right now but the important thing is
 that this trigger sends ``fiber_cond_signal(&replicaset.applier.cond)``
 to the main replicaset instance.
 
-Now back to the caller, i.e. ``applier_sync_state``. The replica
-instances are created we continue walking over appliers
+Now back to the caller, which is the ``applier_sync_state``.
+The replica instances are created and we continue walking over appliers:
 
 .. code-block:: c
 
@@ -278,7 +278,7 @@ and they are moved to global ``replicaset.hash`` tree.
         ...
         rlist_swap(&replicaset.anon, &anon_replicas);
 
-At the end the anonymous replicas (which is not connected)
+At the end the anonymous replicas (ones which are not connected)
 are moved to global ``replicaset.anon``. So we have
 global ``replicaset`` fully consistent and ready for use.
 

--- a/source/replication.rst
+++ b/source/replication.rst
@@ -226,11 +226,11 @@ are linked into red-black tree ``uniq`` for fast lookup via their UUID.
 We allocate new replica and assign an applier to it.
 
 Note that replica state is driven by ``replica_on_applier_state_f``
-trigger. We won't be juming into it right now but the important thing is
+trigger. We won't be jumping into it right now but the important thing is
 that this trigger sends ``fiber_cond_signal(&replicaset.applier.cond)``
 to the main replicaset instance.
 
-Now back to the caller, ie ``applier_sync_state``. The replica
+Now back to the caller, i.e. ``applier_sync_state``. The replica
 instances are created we continue walking over appliers
 
 .. code-block:: c
@@ -278,7 +278,7 @@ and they are moved to global ``replicaset.hash`` tree.
         ...
         rlist_swap(&replicaset.anon, &anon_replicas);
 
-At the end the anonimous replicas (which is not connected)
+At the end the anonymous replicas (which is not connected)
 are moved to global ``replicaset.anon``. So we have
 global ``replicaset`` fully consistent and ready for use.
 
@@ -293,14 +293,14 @@ Now we need to jump up to the initial caller ``bootstrap``.
                 replicaset_foreach(replica) {
                     // Walk over unique replicas
                     // from replicaset hash and
-                    // choose one with more advinsed
+                    // choose one with more advanced
                     // vclock or one with lowest UUID
             return leader;
 
 We need to find out how exactly we should start, either
 we are the master node or we should start from another
-node which is choosen as a cluster leader (ie it has
-most advansed vclock and low UUID).
+node which is chosen as a cluster leader (i.e. it has
+most advanced vclock and low UUID).
 
 Bootstrap first replica
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -687,7 +687,7 @@ Replication in 2.x series
 -------------------------
 
 Generally replication in 2.x series very similar to 1.10 in ideas
-still there are some significant diffierences.
+still there are some significant differences.
 
 The initialization starts with ``box_cfg_xc``.
 
@@ -748,7 +748,7 @@ with anonymous replication and we have some appliers running.
         } 
 
 On a cold start if we gonna be an anonymous replica we just remember the
-setting in `replication_anon`. Then we continue bootstrap procesure
+setting in ``replication_anon``. Then we continue bootstrap procedure
 (we don't consider local recovery for simplicity sake).
 
 First we're trying to reify appliers.

--- a/source/toctree.rst
+++ b/source/toctree.rst
@@ -2,7 +2,7 @@
 
 .. toctree::
    :caption: Contents:
-   :maxdepth: 2
+   :maxdepth: 5
    :includehidden:
 
    fiber


### PR DESCRIPTION
Fixes typos, grammar and punctuation in allocators.md, qsync.rst, fiber.rst, replication.rst.

Partially resolves #17