### PR TITLE
Fail upload_output on first error

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -9,7 +9,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
       AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
       AWS_DEFAULT_REGION: ${{secrets.AWS_DEFAULT_REGION}}
-      ENDPOINT_URL: ${{secrets.ENDPOINT_URL}}
+      ENDPOINT_URL: ${{secrets.S3_ENDPOINT_URL}}
       S3_UPLOAD_PATH: ${{secrets.S3_UPLOAD_PATH}}
       S3_BUCKET: ${{secrets.S3_BUCKET}}
       INTERNALS_UPDATE_URL: ${{secrets.INTERNALS_DEVELOP_UPDATE_URL}}

--- a/upload_output.sh
+++ b/upload_output.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -xe
 DOC_DEST="$S3_UPLOAD_PATH/internals/${BRANCH_NAME}"
 # version in doc project and scripts
 DOC_VERSION=latest
@@ -17,7 +18,6 @@ fi
 
 aws s3 cp build/json "${DOC_DEST}"/json/_build_en/json --endpoint-url="${ENDPOINT_URL}" --recursive --include "*" --exclude "*.jpg" --exclude "*.png" --exclude "*.svg"
 
-set -xe
 curl --fail --show-error \
     --data '{"update_key":"'"${UPDATE_KEY}"'"}' \
     --header "Content-Type: application/json" \


### PR DESCRIPTION
Use `set -xe` before all actions to fail on first error.
Before this change, the job didn't fail when a secret's value
was missing, which resulted in a greed build with non-deployed docs.