### PR TITLE
Strictly check for errors

### DIFF
--- a/.github/workflows/deloy-prod.yml
+++ b/.github/workflows/deloy-prod.yml
@@ -22,5 +22,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - run: sphinx-build -b json source -d build/.doctrees build/json
+      - run: make -f ci.mk json
       - run: bash upload_output.sh

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -28,7 +28,7 @@ jobs:
           env: ${{env.BRANCH_NAME}}
           ref: ${{github.head_ref}}
 
-      - run: sphinx-build -b json source -d build/.doctrees build/json
+      - run: make -f ci.mk json
       - run: bash upload_output.sh
 
       - name: update deployment status

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -n -W
 SPHINXBUILD   = sphinx-build
 AUTOBUILD     = sphinx-autobuild
 SOURCEDIR     = source
@@ -11,7 +11,11 @@ current_dir = $(shell pwd)
 
 # Put it first so that "make" without argument is like "make help".
 help:
-	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	docker run --rm -it -v $(current_dir):/doc tarantool/doc-builder:slim-4.2 sh -c \
+	"$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)"
+
+bash:
+	docker run --rm -it -v $(current_dir):/doc tarantool/doc-builder:slim-4.2 bash
 
 autobuild:
 	docker run --rm -it -p 8000:8000 -v $(current_dir):/doc tarantool/doc-builder:slim-4.2 sh -c \

--- a/ci.mk
+++ b/ci.mk
@@ -1,0 +1,27 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line.
+SPHINXOPTS    = -n -W
+SPHINXBUILD   = sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+current_dir = $(shell pwd)
+
+
+
+clean:
+	rm -rf build
+
+html:
+	sphinx-build -M html \
+	source \
+ 	build \
+ 	$(SPHINXOPTS)
+
+json:
+	sphinx-build -M json \
+	-d build/doctrees \
+	source \
+	build/json \
+	$(SPHINXOPTS)

--- a/source/allocators.md
+++ b/source/allocators.md
@@ -1292,7 +1292,7 @@ matras_alloc(struct matras *m, matras_id_t *result_id)
                                 matras_free_extent(m, extent1);
                         return 0;
                 }
-                extent1[n1] = (void *)extent2;```
+                extent1[n1] = (void *)extent2;
         }
 
         if (extent3_available) {


### PR DESCRIPTION
Sphinx-build options `-n -W` make error checking strict and
fail-fast.

Introduct ci.mk for commands used in CI.