### PR TITLE
Add more internals docs

### DIFF
--- a/source/_static/css/theme_overrides.css
+++ b/source/_static/css/theme_overrides.css
@@ -63,6 +63,37 @@ div[class^="highlight"] pre {
     padding-bottom: 1px;
 }
 
+/*
+  Classes whose names start with "ccode" are a Tarantool extension,
+  see comment in conf.py file: Tarantool custom roles
+*/
+
+.ccode, .ccodeb, .ccodei, .ccodebi {
+    white-space: pre;
+    font-size: 14px;
+    font-family: monospace;
+}
+
+.ccodeb, .ccodebi {
+    font-weight: bold;
+}
+
+.ccodei, .ccodebi {
+    font-style: italic;
+}
+
+.ccodegreen, .ccodebi {
+    color: green;
+}
+
+.ccodeblue, .ccodebi {
+    color: blue;
+}
+
+.ccodered, .ccodebi {
+    color: red;
+}
+
 @media screen {
 
     /* content column

--- a/source/box_protocol.rst
+++ b/source/box_protocol.rst
@@ -851,7 +851,7 @@ IPROTO_RAFT_CONFIRM = 0x28
 This message confirms that the transactions originated from the instance
 with id = IPROTO_REPLICA_ID have achieved quorum and can be committed,
 up to and including LSN = IPROTO_LSN.
-Prior to Tarantool :tarantool-release:`2.10.0`, IPROTO_RAFT_CONFIRM was called IPROTO_CONFIRM.
+Prior to Tarantool :doc:`v. 2.10.0 <community:release/2.10.0>`, IPROTO_RAFT_CONFIRM was called IPROTO_CONFIRM.
 
 The body is a 2-item map:
 

--- a/source/box_protocol.rst
+++ b/source/box_protocol.rst
@@ -215,7 +215,7 @@ In responses Response-Code-Indicator will be followed by IPROTO_OK etc.
 
 **IPROTO_SYNC** = 0x01.
 An unsigned integer that should be incremented so that it is unique in every
-request. This integer is also returned from :doc:`/reference/reference_lua/box_session/sync`.
+request. This integer is also returned from :doc:`community:reference/reference_lua/box_session/sync`.
 The IPROTO_SYNC value of a response should be the same as
 the IPROTO_SYNC value of a request.
 
@@ -264,7 +264,7 @@ that contains the IPROTO key, and a body as described here.
 IPROTO_SELECT = 0x01
 ~~~~~~~~~~~~~~~~~~~~
 
-See :ref:`space_object:select() <box_space-select>`.
+See :ref:`space_object:select() <community:box_space-select>`.
 The body is a 6-item map.
 
 ..  cssclass:: highlight
@@ -318,7 +318,7 @@ we will show actual byte codes of an IPROTO_SELECT message.
 IPROTO_INSERT = 0x02
 ~~~~~~~~~~~~~~~~~~~~
 
-See :ref:`space_object:insert()  <box_space-insert>`.
+See :ref:`space_object:insert()  <community:box_space-insert>`.
 The body is a 2-item map:
 
 ..  cssclass:: highlight
@@ -361,7 +361,7 @@ Example: if the id of 'tspace' is 512 and this is the fifth message, |br|
 IPROTO_REPLACE = 0x03
 ~~~~~~~~~~~~~~~~~~~~~
 
-See :ref:`space_object:replace()  <box_space-replace>`.
+See :ref:`space_object:replace()  <community:box_space-replace>`.
 The body is a 2-item map, the same as for IPROTO_INSERT:
 
 ..  cssclass:: highlight
@@ -386,7 +386,7 @@ The body is a 2-item map, the same as for IPROTO_INSERT:
 IPROTO_UPDATE = 0x04
 ~~~~~~~~~~~~~~~~~~~~
 
-See :ref:`space_object:update()  <box_space-update>`.
+See :ref:`space_object:update()  <community:box_space-update>`.
 
 The body is usually a 4-item map:
 
@@ -448,7 +448,7 @@ we will show actual byte codes of an IPROTO_UPDATE message.
 IPROTO_DELETE = 0x05
 ~~~~~~~~~~~~~~~~~~~~
 
-See :ref:`space_object:delete()  <box_space-delete>`.
+See :ref:`space_object:delete()  <community:box_space-delete>`.
 The body is a 3-item map:
 
 ..  cssclass:: highlight
@@ -474,7 +474,7 @@ The body is a 3-item map:
 IPROTO_CALL_16 = 0x06
 ~~~~~~~~~~~~~~~~~~~~~
 
-See :ref:`conn:call() <net_box-call>`. The suffix ``_16`` is a hint that this is
+See :ref:`conn:call() <community:net_box-call>`. The suffix ``_16`` is a hint that this is
 for the ``call()`` until Tarantool 1.6. It is deprecated.
 Use :ref:`IPROTO_CALL <box_protocol-call>` instead.
 The body is a 2-item map:
@@ -503,7 +503,7 @@ The return value is an array of tuples.
 IPROTO_AUTH = 0x07
 ~~~~~~~~~~~~~~~~~~
 
-See :ref:`authentication <authentication-users>`.
+See :ref:`authentication <community:authentication-users>`.
 See the later section :ref:`Binary protocol -- authentication <box_protocol-authentication>`.
 
 
@@ -512,14 +512,14 @@ See the later section :ref:`Binary protocol -- authentication <box_protocol-auth
 IPROTO_EVAL = 0x08
 ~~~~~~~~~~~~~~~~~~
 
-See :ref:`conn:eval() <net_box-eval>`.
+See :ref:`conn:eval() <community:net_box-eval>`.
 Since the argument is a Lua expression, this is
 Tarantool's way to handle non-binary with the
 binary protocol. Any request that does not have
 its own code, for example :samp:`box.space.{space-name}:drop()`,
 will be handled either with :ref:`IPROTO_CALL <box_protocol-call>`
 or IPROTO_EVAL.
-The :ref:`tarantoolctl <tarantoolctl>` administrative utility
+The :ref:`tarantoolctl <community:tarantoolctl>` administrative utility
 makes extensive use of ``eval``.
 The body is a 2-item map:
 
@@ -562,7 +562,7 @@ Example: if this is the fifth message, :samp:`conn:eval('return 5;')` will cause
 IPROTO_UPSERT = 0x09
 ~~~~~~~~~~~~~~~~~~~~
 
-See :ref:`space_object:upsert()  <box_space-upsert>`.
+See :ref:`space_object:upsert()  <community:box_space-upsert>`.
 
 The body is usually a 4-item map:
 
@@ -592,7 +592,7 @@ The IPROTO_OPS is the same as the IPROTO_TUPLE of :ref:`IPROTO_UPDATE <box_proto
 IPROTO_CALL = 0x0a
 ~~~~~~~~~~~~~~~~~~
 
-See :ref:`conn:call() <net_box-call>`.
+See :ref:`conn:call() <community:net_box-call>`.
 The body is a 2-item map:
 
 ..  cssclass:: highlight
@@ -620,7 +620,7 @@ The response will be a list of values, similar to the
 IPROTO_EXECUTE = 0x0b
 ~~~~~~~~~~~~~~~~~~~~~
 
-See :ref:`box.execute() <box-sql_box_execute>`, this is only for SQL.
+See :ref:`box.execute() <community:box-sql_box_execute>`, this is only for SQL.
 The body is a 3-item map:
 
 ..  cssclass:: highlight
@@ -692,7 +692,7 @@ The body is: nothing.
 IPROTO_PREPARE = 0x0d
 ~~~~~~~~~~~~~~~~~~~~~
 
-See :ref:`box.prepare <box-sql_box_prepare>`, this is only for SQL.
+See :ref:`box.prepare <community:box-sql_box_prepare>`, this is only for SQL.
 The body is a 1-item map:
 
 ..  cssclass:: highlight
@@ -722,7 +722,7 @@ IPROTO_BEGIN = 0x0e
 ~~~~~~~~~~~~~~~~~~~
 
 Begin a transaction in the specified stream.
-See :ref:`stream:begin() <net_box-stream_begin>`.
+See :ref:`stream:begin() <community:net_box-stream_begin>`.
 The body is optional and can contain two items:
 
 ..  cssclass:: highlight
@@ -745,7 +745,7 @@ The body is optional and can contain two items:
 IPROTO_TIMEOUT is an optional timeout (in seconds). After it expires,
 the transaction will be rolled back automatically.
 
-IPROTO_TXN_ISOLATION is the :ref:`transaction isolation level <txn_mode_mvcc-options>`.
+IPROTO_TXN_ISOLATION is the :ref:`transaction isolation level <community:txn_mode_mvcc-options>`.
 It can take the following values:
 
 - ``TXN_ISOLATION_DEFAULT = 0``	-- use the default level from ``box.cfg`` (default value)
@@ -762,7 +762,7 @@ IPROTO_COMMIT = 0x0f
 ~~~~~~~~~~~~~~~~~~~~
 
 Commit the transaction in the specified stream.
-See :ref:`stream:commit() <net_box-stream_commit>`.
+See :ref:`stream:commit() <community:net_box-stream_commit>`.
 
 ..  cssclass:: highlight
 ..  parsed-literal::
@@ -786,7 +786,7 @@ IPROTO_ROLLBACK = 0x10
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Rollback the transaction in the specified stream.
-See :ref:`stream:rollback() <net_box-stream_rollback>`.
+See :ref:`stream:rollback() <community:net_box-stream_rollback>`.
 
 ..  cssclass:: highlight
 ..  parsed-literal::
@@ -809,7 +809,7 @@ stream transactions in the binary protocol.
 IPROTO_PING = 0x40
 ~~~~~~~~~~~~~~~~~~
 
-See :ref:`conn:ping() <conn-ping>`. The body will be an empty map because IPROTO_PING
+See :ref:`conn:ping() <community:conn-ping>`. The body will be an empty map because IPROTO_PING
 in the header contains all the information that the server instance needs.
 
 ..  cssclass:: highlight
@@ -839,7 +839,7 @@ Connectors and clients do not need to send replication packets.
 See :ref:`Binary protocol -- replication <box_protocol-replication>`.
 
 The next two IPROTO messages are used in replication connections between
-Tarantool nodes in :ref:`synchronous replication <repl_sync>`.
+Tarantool nodes in :ref:`synchronous replication <community:repl_sync>`.
 The messages are not supposed to be used by any client applications in their
 regular connections.
 
@@ -968,11 +968,11 @@ Watchers
 --------
 
 The commands below support asynchronous server-client notifications signalled
-with :ref:`box.broadcast() <box-broadcast>`.
+with :ref:`box.broadcast() <community:box-broadcast>`.
 Servers that support the new feature set the ``IPROTO_FEATURE_WATCHERS`` feature in reply to the ``IPROTO_ID`` command.
 When the connection is closed, all watchers registered for it are unregistered.
 
-The remote :ref:`watcher <box-watchers>` protocol works in the following way:
+The remote :ref:`watcher <community:box-watchers>` protocol works in the following way:
 
 #.  The client sends an ``IPROTO_WATCH`` packet to subscribe to the updates of a specified key defined on the server.
 
@@ -1142,11 +1142,11 @@ a successful response will look like this:
 Later in :ref:`Binary protocol -- illustration <box_protocol-illustration>`
 we will show actual byte codes of the response to the IPROTO_INSERT message.
 
-IPROTO_DATA is what we get with net_box and :ref:`Module buffer <buffer-module>`
+IPROTO_DATA is what we get with net_box and :ref:`Module buffer <community:buffer-module>`
 so if we were using net_box we could decode with
-:ref:`msgpack.decode_unchecked() <msgpack-decode_unchecked_string>`,
+:ref:`msgpack.decode_unchecked() <community:msgpack-decode_unchecked_string>`,
 or we could convert to a string with :samp:`ffi.string({pointer},{length})`.
-The :ref:`pickle.unpack() <pickle-unpack>` function might also be helpful.
+The :ref:`pickle.unpack() <community:pickle-unpack>` function might also be helpful.
 
 ..  _box_protocol-responses_out_of_band:
 
@@ -1154,7 +1154,7 @@ Responses for no error and out-of-band
 --------------------------------------
 
 If the response is out-of-band, due to use of
-:ref:`box.session.push() <box_session-push>`,
+:ref:`box.session.push() <community:box_session-push>`,
 then the header Response-Code-Indicator will be IPROTO_CHUNK instead of IPROTO_OK.
 
 ..  _box_protocol-responses_error:
@@ -1214,7 +1214,7 @@ Looking in errcode.h we find that error code 0x0a (decimal 10) is
 ER_SPACE_EXISTS, and the string associated with ER_SPACE_EXISTS is
 "Space '%s' already exists".
 
-Since version :doc:`2.4.1 </release/2.4.1>`, responses for errors have extra information
+Since version :doc:`2.4.1 <community:release/2.4.1>`, responses for errors have extra information
 following what was described above. This extra information is given via
 MP_ERROR extension type. See details in :ref:`MessagePack extensions
 <msgpack_ext-error>` section.
@@ -1285,10 +1285,10 @@ If the SQL statement is SELECT or VALUES or PRAGMA, the response contains:
 * :samp:`IPROTO_METADATA: {array of column maps}` = array of column maps, with each column map containing
   at least IPROTO_FIELD_NAME (0x00) and MP_STR, and IPROTO_FIELD_TYPE (0x01) and MP_STR.
   Additionally, if ``sql_full_metadata`` in the
-  :ref:`_session_settings <box_space-session_settings>` system space
+  :ref:`_session_settings <community:box_space-session_settings>` system space
   is TRUE, then the array will have these additional column maps
   which correspond to components described in the
-  :ref:`box.execute() <box-sql_if_full_metadata>` section:
+  :ref:`box.execute() <community:box-sql_if_full_metadata>` section:
 
 ..  code-block:: none
 
@@ -1454,7 +1454,7 @@ function ``netbox_encode_auth``.
 Binary protocol -- streams
 --------------------------
 
-The :ref:`Streams and interactive transactions <txn_mode_stream-interactive-transactions>`
+The :ref:`Streams and interactive transactions <community:txn_mode_stream-interactive-transactions>`
 feature, which was added in Tarantool version
 :tarantool-release:`2.10.0`, allows two things:
 sequential processing and interleaving.
@@ -1470,14 +1470,14 @@ For example, a series of requests can include
 for stream #1", "commit for stream #1", "rollback for stream #2".
 
 To make these things possible,
-the engine should be :ref:`vinyl <engines-vinyl>` or :ref:`memtx with mvcc <cfg_basic-memtx_use_mvcc_engine>`, and
+the engine should be :ref:`vinyl <community:engines-vinyl>` or :ref:`memtx with mvcc <community:cfg_basic-memtx_use_mvcc_engine>`, and
 the client is responsible for ensuring that the stream identifier,
 unsigned integer :ref:`IPROTO_STREAM_ID <box_protocol-iproto_stream_id>`, is in the request header.
 IPROTO_STREAM_ID can be any positive 64-bit number, and should be unique for the connection.
 If IPROTO_STREAM_ID equals zero the server instance will ignore it.
 
 For example, suppose that the client has started a stream with
-the :ref:`net.box module <net_box-module>`
+the :ref:`net.box module <community:net_box-module>`
 
 ..  code-block:: lua
 
@@ -1517,8 +1517,8 @@ Thus there are now multiple ways to do transactions:
 with ``net_box`` ``stream:begin()`` and ``stream:commit()`` or ``stream:rollback()``
 which cause IPROTO_BEGIN and IPROTO_COMMIT or IPROTO_ROLLBACK with
 the current value of stream.stream_id;
-with :ref:`box.begin() <box-begin>` and :ref:`box.commit() <box-commit>` or :ref:`box.rollback() <box-rollback>`;
-with SQL and :ref:`START TRANSACTION <sql_start_transaction>` and :ref:`COMMIT <sql_commit>` or :ref:`ROLLBACK <sql_rollback>`.
+with :ref:`box.begin() <community:box-begin>` and :ref:`box.commit() <community:box-commit>` or :ref:`box.rollback() <community:box-rollback>`;
+with SQL and :ref:`START TRANSACTION <community:sql_start_transaction>` and :ref:`COMMIT <community:sql_commit>` or :ref:`ROLLBACK <community:sql_rollback>`.
 An application can use any or all of these ways.
 
 ..  _box_protocol-replication:
@@ -1597,7 +1597,7 @@ Every request between masters will have additional LSN and SERVER_ID.
 HEARTBEATS
 ~~~~~~~~~~
 
-Frequently a master sends a :ref:`heartbeat <heartbeat>` message to a replica.
+Frequently a master sends a :ref:`heartbeat <community:heartbeat>` message to a replica.
 For example, if there is a replica with id = 2,
 and a timestamp with a moment in 2020, a master might send this:
 
@@ -1646,44 +1646,44 @@ The fields within IPROTO_BALLOT are map items:
 
 
 IPROTO_BALLOT_IS_RO_CFG and IPRO_BALLOT_VCLOCK and IPROTO_BALLOT_GC_VCLOCK and IPROTO_BALLOT_IS_RO
-were added in version :doc:`2.6.1 </release/2.6.1>`.
-IPROTO_BALLOT_IS_ANON was added in version :doc:`2.7.1 </release/2.7.1>`.
+were added in version :doc:`2.6.1 <community:release/2.6.1>`.
+IPROTO_BALLOT_IS_ANON was added in version :doc:`2.7.1 <community:release/2.7.1>`.
 IPROTO_BALLOT_IS_BOOTED was added in version 2.7.3 and 2.8.2 and 2.9.1.
 There have been some name changes starting with version 2.7.3 and 2.8.2 and 2.9.1:
 IPROTO_BALLOT_IS_RO_CFG was formerly called IPROTO_BALLOT_IS_RO,
 and IPROTO_BALLOT_IS_RO was formerly called IPROTO_BALLOT_IS_LOADING.
 
-IPROTO_BALLOT_IS_RO_CFG corresponds to :ref:`box.cfg.read_only <cfg_basic-read_only>`.
+IPROTO_BALLOT_IS_RO_CFG corresponds to :ref:`box.cfg.read_only <community:cfg_basic-read_only>`.
 
 IPROTO_BALLOT_GC_VCLOCK can be the vclock value of the instance's oldest
-WAL entry, which corresponds to :ref:`box.info.gc().vclock <box_info_gc>`.
+WAL entry, which corresponds to :ref:`box.info.gc().vclock <community:box_info_gc>`.
 
 IPROTO_BALLOT_IS_RO is true if the instance is not writable,
 which may happen for a variety of reasons, such as:
-it was configured as :ref:`read_only <cfg_basic-read_only>`,
-or it has :ref:`orphan status <replication-orphan_status>`,
-or it is a :ref:`Raft <repl_leader_elect>` follower.
+it was configured as :ref:`read_only <community:cfg_basic-read_only>`,
+or it has :ref:`orphan status <community:replication-orphan_status>`,
+or it is a :ref:`Raft <community:repl_leader_elect>` follower.
 
-IPROTO_BALLOT_IS_ANON corresponds to :ref:`box.cfg.replication_anon <cfg_replication-replication_anon>`.
+IPROTO_BALLOT_IS_ANON corresponds to :ref:`box.cfg.replication_anon <community:cfg_replication-replication_anon>`.
 
 IPROTO_BALLOT_IS_BOOTED is true if the instance has finished its
 bootstrap or recovery process.
 
-IPROTO_BALLOT_CAN_LEAD is true if the :ref:`election_mode <cfg_replication-election_mode>`
+IPROTO_BALLOT_CAN_LEAD is true if the :ref:`election_mode <community:cfg_replication-election_mode>`
 configuration setting is either 'candidate' or 'manual', so that
-during the :ref:`leader election process <repl_leader_elect_process>`
+during the :ref:`leader election process <community:repl_leader_elect_process>`
 this instance may be preferred over instances whose configuration
 setting is 'voter'.
 IPROTO_BALLOT_CAN_LEAD support was added simultaneously in
-version :doc:`2.7.3 </release/2.7.3>`
-and version :doc:`2.8.2 </release/2.8.2>`.
+version :doc:`2.7.3 <community:release/2.7.3>`
+and version :doc:`2.8.2 <community:release/2.8.2>`.
 
 ..  _box_protocol-flags:
 
 FLAGS
 ~~~~~
 
-For replication of :doc:`synchronous transactions </book/replication/repl_sync>`
+For replication of :doc:`synchronous transactions <community:book/replication/repl_sync>`
 a header may contain a key = IPROTO_FLAGS and an MP_UINT value = one or more
 bits: IPROTO_FLAG_COMMIT or IPROTO_FLAG_WAIT_SYNC or IPROTO_FLAG_WAIT_ACK.
 
@@ -1735,8 +1735,8 @@ In other words, there should be a full-mesh connection between the nodes.
         IPROTO_RAFT_VOTE: :samp:`{{MP_UINT unsigned integer}}`,     # Instance vote in the current term (if any).
         IPROTO_RAFT_STATE: :samp:`{{MP_UINT unsigned integer}}`,    # Instance state. Possible values: 1 -- follower, 2 -- candidate, 3 -- leader.
         IPROTO_RAFT_VCLOCK: :samp:`{{MP_ARRAY {{MP_INT SRV_ID, MP_INT SRV_LSN}, {MP_INT SRV_ID, MP_INT SRV_LSN}, ...}}}`,   # Current vclock of the instance. Presents only on the instances in the "candidate" state (IPROTO_RAFT_STATE == 2).
-        IPROTO_RAFT_LEADER_ID: :samp:`{{MP_UINT unsigned integer}}`,     # Current leader node ID as seen by the node that issues the request. Since version :doc:`2.10.0 </release/2.10.0>`.
-        IPROTO_RAFT_IS_LEADER_SEEN: :samp:`{{MP_BOOL boolean}}`     # Shows whether the node has a direct connection to the leader node. Since version :doc:`2.10.0 </release/2.10.0>`.
+        IPROTO_RAFT_LEADER_ID: :samp:`{{MP_UINT unsigned integer}}`,     # Current leader node ID as seen by the node that issues the request. Since version :doc:`2.10.0 <community:release/2.10.0>`.
+        IPROTO_RAFT_IS_LEADER_SEEN: :samp:`{{MP_BOOL boolean}}`     # Shows whether the node has a direct connection to the leader node. Since version :doc:`2.10.0 <community:release/2.10.0>`.
 
     })
 
@@ -1815,7 +1815,7 @@ C programmers sometimes include `msgpuck.h <https://github.com/rtsisyk/msgpuck>`
 
 Now you know how Tarantool itself makes requests with the binary protocol.
 When in doubt about a detail, consult ``net_box.c`` -- it has routines for each
-request. Some :ref:`connectors <index-box_connectors>` have similar code.
+request. Some :ref:`connectors <community:index-box_connectors>` have similar code.
 
 For an IPROTO_UPDATE example, suppose a user changes field #2 in tuple #2
 in space #256 to ``'BBBB'``. The body will look like this:
@@ -2057,4 +2057,4 @@ may be data tuples that have this form:
     +============+ +===================================+
          MP_MAP                     MP_MAP
 
-See the example in the :ref:`File formats <internals-data_persistence>` section.
+See the example in the :ref:`File formats <community:internals-data_persistence>` section.

--- a/source/box_protocol.rst
+++ b/source/box_protocol.rst
@@ -1456,7 +1456,7 @@ Binary protocol -- streams
 
 The :ref:`Streams and interactive transactions <community:txn_mode_stream-interactive-transactions>`
 feature, which was added in Tarantool version
-:tarantool-release:`2.10.0`, allows two things:
+:doc:`2.10.0 <community:release/2.10.0>`, allows two things:
 sequential processing and interleaving.
 
 Sequential processing:

--- a/source/box_protocol.rst
+++ b/source/box_protocol.rst
@@ -1,0 +1,2060 @@
+..  _box_protocol-iproto_protocol:
+
+..  _internals-box_protocol:
+
+Binary protocol
+===============
+
+The binary protocol is called a "request/response" protocol because it is
+for sending requests to a Tarantool server and receiving responses.
+There is complete access to Tarantool functionality, including:
+
+- request multiplexing, for example ability to issue multiple requests
+  asynchronously via the same connection
+- response format that supports zero-copy writes
+
+The protocol can be called "binary" because the most-frequently-used database accesses
+are done with binary codes instead of Lua request text. Tarantool experts use it
+to write their own connectors,
+to understand network messages,
+to support new features that their favorite connector doesn't support yet,
+or to avoid repetitive parsing by the server.
+
+..  _box_protocol-notation:
+
+Symbols and terms
+-----------------
+
+Words that start with **MP_** mean:
+a `MessagePack <http://MessagePack.org>`_ type or a range of MessagePack types,
+including the signal and possibly including a value, with slight modification:
+
+* **MP_NIL**    nil
+* **MP_UINT**   unsigned integer
+* **MP_INT**    either integer or unsigned integer
+* **MP_STR**    string
+* **MP_BIN**    binary string
+* **MP_ARRAY**  array
+* **MP_MAP**    map
+* **MP_BOOL**   boolean
+* **MP_FLOAT**  float
+* **MP_DOUBLE** double
+* **MP_EXT**    extension (including the :ref:`DECIMAL type <msgpack_ext-decimal>` and UUID type)
+* **MP_OBJECT** any MessagePack object
+
+Short descriptions are in MessagePack's `"spec" page <https://github.com/msgpack/msgpack/blob/master/spec.md>`_.
+
+And words that start with **IPROTO_** mean:
+a Tarantool constant which is either defined or mentioned in the
+`iproto_constants.h file <https://github.com/tarantool/tarantool/blob/master/src/box/iproto_constants.h>`_.
+
+The IPROTO constants that identify requests that we will mention in this section are:
+
+..  code-block:: lua
+
+    IPROTO_SELECT=0x01
+    IPROTO_INSERT=0x02
+    IPROTO_REPLACE=0x03
+    IPROTO_UPDATE=0x04
+    IPROTO_DELETE=0x05
+    IPROTO_CALL_16=0x06
+    IPROTO_AUTH=0x07
+    IPROTO_EVAL=0x08
+    IPROTO_UPSERT=0x09
+    IPROTO_CALL=0x0a
+    IPROTO_EXECUTE=0x0b
+    IPROTO_NOP=0x0c
+    IPROTO_PREPARE=0x0d
+    IPROTO_BEGIN=0x0e
+    IPROTO_COMMIT=0x0f
+    IPROTO_ROLLBACK=0x10
+    IPROTO_RAFT_CONFIRM=0x28
+    IPROTO_RAFT_ROLLBACK=0x29
+    IPROTO_RAFT=0x1e
+    IPROTO_RAFT_PROMOTE=0x1f
+    IPROTO_RAFT_DEMOTE=0x20
+    IPROTO_PING=0x40
+    IPROTO_JOIN=0x41
+    IPROTO_SUBSCRIBE=0x42
+    IPROTO_VOTE_DEPRECATED=0x43
+    IPROTO_VOTE=0x44
+    IPROTO_FETCH_SNAPSHOT=0x45
+    IPROTO_REGISTER=0x46
+    IPROTO_ID=0x49
+    IPROTO_WATCH=0x4a
+    IPROTO_UNWATCH=0x4b
+    IPROTO_EVENT=0x4c
+
+
+The IPROTO constants that appear within requests or responses that we will describe in this section are:
+
+..  code-block:: lua
+
+    IPROTO_OK=0x00
+    IPROTO_REQUEST_TYPE=0x00
+    IPROTO_SYNC=0x01
+    IPROTO_REPLICA_ID=0x02
+    IPROTO_LSN=0x03
+    IPROTO_TIMESTAMP=0x04
+    IPROTO_SCHEMA_VERSION=0x05
+    IPROTO_FLAGS=0x09
+    IPROTO_STREAM_ID=0x0a
+    IPROTO_SPACE_ID=0x10
+    IPROTO_INDEX_ID=0x11
+    IPROTO_LIMIT=0x12
+    IPROTO_OFFSET=0x13
+    IPROTO_ITERATOR=0x14
+    IPROTO_INDEX_BASE=0x15
+    IPROTO_KEY=0x20
+    IPROTO_TUPLE=0x21
+    IPROTO_FUNCTION_NAME=0x22
+    IPROTO_USER_NAME=0x23
+    IPROTO_INSTANCE_UUID=0x24
+    IPROTO_CLUSTER_UUID=0x25
+    IPROTO_VCLOCK=0x26
+    IPROTO_EXPR=0x27
+    IPROTO_OPS=0x28
+    IPROTO_BALLOT=0x29
+    IPROTO_BALLOT_IS_RO_CFG=0x01
+    IPROTO_BALLOT_VCLOCK=0x02
+    IPROTO_BALLOT_GC_VCLOCK=0x03
+    IPROTO_BALLOT_IS_RO=0x04
+    IPROTO_BALLOT_IS_ANON=0x05
+    IPROTO_BALLOT_IS_BOOTED=0x06
+    IPROTO_BALLOT_CAN_LEAD=0x07
+    IPROTO_TUPLE_META=0x2a
+    IPROTO_OPTIONS=0x2b
+    IPROTO_DATA=0x30
+    IPROTO_ERROR_24=0x31
+    IPROTO_METADATA=0x32
+    IPROTO_BIND_METADATA=0x33
+    IPROTO_BIND_COUNT=0x34
+    IPROTO_SQL_TEXT=0x40
+    IPROTO_SQL_BIND=0x41
+    IPROTO_SQL_INFO=0x42
+    IPROTO_STMT_ID=0x43
+    IPROTO_ERROR=0x52
+    IPROTO_FIELD_NAME=0x00
+    IPROTO_FIELD_TYPE=0x01
+    IPROTO_FIELD_COLL=0x02
+    IPROTO_FIELD_IS_NULLABLE=0x03
+    IPROTO_FIELD_IS_AUTOINCREMENT=0x04
+    IPROTO_FIELD_SPAN=0x05
+    IPROTO_CHUNK=0x80
+    IPROTO_RAFT_TERM=0x00
+    IPROTO_RAFT_VOTE=0x01
+    IPROTO_RAFT_STATE=0x02
+    IPROTO_RAFT_VCLOCK=0x03
+    IPROTO_RAFT_LEADER_ID=0x04
+    IPROTO_RAFT_IS_LEADER_SEEN=0x05
+    IPROTO_VERSION=0x54
+    IPROTO_FEATURES=0x55
+    IPROTO_TIMEOUT=0x56
+    IPROTO_EVENT_KEY=0x57
+    IPROTO_EVENT_DATA=0x58
+    IPROTO_TXN_ISOLATION=0x59
+
+
+To denote message descriptions we will say ``msgpack(...)`` and within it we will use modified
+`YAML <https://en.wikipedia.org/wiki/YAML>`_ so: |br|
+
+:code:`{...}` braces enclose an associative array, also called map, which in MsgPack is MP_MAP, |br|
+:samp:`{k}: {v}` is a key-value pair, also called map-item, in this section k is always an unsigned-integer value = one of the IPROTO constants, |br|
+:samp:`{italics}` are for replaceable text, which is the convention throughout this manual. Usually this is a data type but we do not show types of IPROTO constants
+which happen to always be unsigned 8-bit integers, |br|
+:code:`[...]` is for non-associative arrays, |br|
+:code:`#` starts a comment, especially for the beginning of a section, |br|
+everything else is "as is". |br|
+Map-items may appear in any order but in examples we usually use the order that net_box.c happens to use.
+
+..  _internals-unified_packet_structure:
+
+..  _box_protocol-header:
+
+Header and body
+---------------
+
+Except during connection (which involves a greeting from the server and optional
+:ref:`authentication <box_protocol-authentication>` that we will discuss later
+in this section), the protocol is pure request/response (the client requests and
+the server responds). It is legal to put more than one request in a packet.
+
+Almost all requests and responses contain three sections: size, header, and body.
+The size is an (MP_UINT) unsigned integer, usually a 32-bit unsigned integer.
+The header and body are (MP_MAP) maps.
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <size>
+    :samp:`{{MP_UINT unsigned integer}}`
+    # <header>
+    :samp:`{{MP_MAP with <header> map-items}}`
+    # <body>
+    :samp:`{{MP_MAP with <body> map-items}}`
+
+``<size>`` is the size of the header plus the size of the body.
+It may be useful to compare it with the number of bytes remaining in the packet.
+
+``<header>`` may contain, in any order:
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    msgpack({
+        IPROTO_REQUEST_TYPE: :samp:`{{MP_UINT unsigned integer}}`,
+        IPROTO_SYNC: :samp:`{{MP_UINT unsigned integer}}`,
+        IPROTO_SCHEMA_VERSION: :samp:`{{MP_UINT unsigned integer}}`
+        IPROTO_STREAM_ID: :samp:`{{MP_UINT unsigned integer}}`
+    })
+
+**IPROTO_REQUEST_TYPE** or Response-Code-Indicator = 0x00.
+An unsigned number that indicates what will be in the ``<body>``.
+In requests IPROTO_REQUEST_TYPE will be followed by IPROTO_SELECT etc.
+In responses Response-Code-Indicator will be followed by IPROTO_OK etc.
+
+**IPROTO_SYNC** = 0x01.
+An unsigned integer that should be incremented so that it is unique in every
+request. This integer is also returned from :doc:`/reference/reference_lua/box_session/sync`.
+The IPROTO_SYNC value of a response should be the same as
+the IPROTO_SYNC value of a request.
+
+**IPROTO_SCHEMA_VERSION** = 0x05.
+An unsigned number, sometimes called SCHEMA_ID, that goes up when there is a
+major change.
+In a request header IPROTO_SCHEMA_VERSION is optional, so the version will not
+be checked if it is absent.
+In a response header IPROTO_SCHEMA_VERSION is always present, and it is up to
+the client to check if it has changed.
+
+..  _box_protocol-iproto_stream_id:
+
+**IPROTO_STREAM_ID** = 0x0a.
+An unsigned number that should be unique in every stream.
+In requests IPROTO_STREAM_ID is optional and is useful for two things:
+ensuring that requests within transactions are done in separate groups,
+and ensuring strictly consistent execution of requests (whether or not they are within transactions).
+In responses IPROTO_STREAM_ID does not appear.
+See :ref:`Binary protocol -- streams <box_protocol-streams>`.
+
+Have a look at file
+`xrow.c <https://github.com/tarantool/tarantool/blob/master/src/box/xrow.c>`_
+function ``xrow_header_encode``, to see how Tarantool encodes the header.
+Have a look at file net_box.c, function ``netbox_decode_data``, to see how Tarantool
+decodes the header. For example, in a successful response to ``box.space:select()``,
+the Response-Code-Indicator value will be 0 = IPROTO_OK and the
+array will have all the tuples of the result.
+
+The ``<body>`` has the details of the request or response. In a request, it can also
+be absent or be an empty map. Both these states will be interpreted equally.
+Responses will contain the ``<body>`` anyway even for an
+:ref:`IPROTO_PING <box_protocol-ping>` request.
+
+..  _box_protocol-requests:
+
+Requests
+--------
+
+A request has a size, a :ref:`header <box_protocol-header>`
+that contains the IPROTO key, and a body as described here.
+
+
+..  _box_protocol-select:
+
+IPROTO_SELECT = 0x01
+~~~~~~~~~~~~~~~~~~~~
+
+See :ref:`space_object:select() <box_space-select>`.
+The body is a 6-item map.
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <size>
+    msgpack(:samp:`{{MP_UINT unsigned integer = size(<header>) + size(<body>)}}`)
+    # <header>
+    msgpack({
+        IPROTO_REQUEST_TYPE: IPROTO_SELECT,
+        IPROTO_SYNC: :samp:`{{MP_UINT unsigned integer}}`
+    })
+    # <body>
+    msgpack({
+        IPROTO_SPACE_ID: :samp:`{{MP_UINT unsigned integer}}`,
+        IPROTO_INDEX_ID: :samp:`{{MP_UINT unsigned integer}}`,
+        IPROTO_LIMIT: :samp:`{{MP_UINT unsigned integer}}`,
+        IPROTO_OFFSET: :samp:`{{MP_UINT unsigned integer}}`,
+        IPROTO_ITERATOR: :samp:`{{MP_UINT unsigned integer}}`,
+        IPROTO_KEY: :samp:`{{MP_ARRAY array of key values}}`
+    })
+
+Example: if the id of 'tspace' is 512 and this is the fifth message, |br|
+:samp:`{conn}.`:code:`space.tspace:select({0},{iterator='GT',offset=1,limit=2})` will cause:
+
+..  code-block:: none
+
+    <size>
+    msgpack(21)
+    # <header>
+    msgpack({
+        IPROTO_SYNC: 5,
+        IPROTO_REQUEST_TYPE: IPROTO_SELECT
+    })
+    # <body>
+    msgpack({
+        IPROTO_SPACE_ID: 512,
+        IPROTO_INDEX_ID: 0,
+        IPROTO_ITERATOR: 6,
+        IPROTO_OFFSET: 1,
+        IPROTO_LIMIT: 2,
+        IPROTO_KEY: [1]
+    })
+
+Later in :ref:`Binary protocol -- illustration <box_protocol-illustration>`
+we will show actual byte codes of an IPROTO_SELECT message.
+
+
+..  _box_protocol-insert:
+
+IPROTO_INSERT = 0x02
+~~~~~~~~~~~~~~~~~~~~
+
+See :ref:`space_object:insert()  <box_space-insert>`.
+The body is a 2-item map:
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <size>
+    msgpack(:samp:`{{MP_UINT unsigned integer = size(<header>) + size(<body>)}}`)
+    # <header>
+    msgpack({
+        IPROTO_REQUEST_TYPE: IPROTO_INSERT,
+        IPROTO_SYNC: :samp:`{{MP_UINT unsigned integer}}`
+    })
+    # <body>
+    msgpack({
+        IPROTO_SPACE_ID: :samp:`{{MP_UINT unsigned integer}}`,
+        IPROTO_TUPLE: :samp:`{{MP_ARRAY array of field values}}`
+    })
+
+Example: if the id of 'tspace' is 512 and this is the fifth message, |br|
+:samp:`{conn}.`:code:`space.tspace:insert{1, 'AAA'}` will cause:
+
+..  code-block:: none
+
+    # <size>
+    msgpack(17)
+    # <header>
+    msgpack({
+        IPROTO_REQUEST_TYPE: IPROTO_INSERT,
+        IPROTO_SYNC: 5
+    })
+    # <body>
+    msgpack({
+        IPROTO_SPACE_ID: 512,
+        IPROTO_TUPLE: [1, 'AAA']
+    })
+
+
+..  _box_protocol-replace:
+
+IPROTO_REPLACE = 0x03
+~~~~~~~~~~~~~~~~~~~~~
+
+See :ref:`space_object:replace()  <box_space-replace>`.
+The body is a 2-item map, the same as for IPROTO_INSERT:
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <size>
+    msgpack(:samp:`{{MP_UINT unsigned integer = size(<header>) + size(<body>)}}`)
+    # <header>
+    msgpack({
+        IPROTO_REQUEST_TYPE: IPROTO_REPLACE,
+        IPROTO_SYNC: :samp:`{{MP_UINT unsigned integer}}`
+    })
+    # <body>
+    msgpack({
+        IPROTO_SPACE_ID: :samp:`{{MP_UINT unsigned integer}}`,
+        IPROTO_TUPLE: :samp:`{{MP_ARRAY array of field values}}`
+    })
+
+
+..  _box_protocol-update:
+
+IPROTO_UPDATE = 0x04
+~~~~~~~~~~~~~~~~~~~~
+
+See :ref:`space_object:update()  <box_space-update>`.
+
+The body is usually a 4-item map:
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <size>
+    msgpack(:samp:`{{MP_UINT unsigned integer = size(<header>) + size(<body>)}}`)
+    # <header>
+    msgpack({
+        IPROTO_REQUEST_TYPE: IPROTO_UPDATE,
+        IPROTO_SYNC: :samp:`{{MP_UINT unsigned integer}}`
+    })
+    # <body>
+    msgpack({
+        IPROTO_SPACE_ID: :samp:`{{MP_UINT unsigned integer}}`,
+        IPROTO_INDEX_ID: :samp:`{{MP_UINT unsigned integer}}`,
+        IPROTO_KEY: :samp:`{{MP_ARRAY array of index keys}}`,
+        IPROTO_TUPLE: :samp:`{{MP_ARRAY array of update operations}}`
+    })
+
+If the operation specifies no values, then IPROTO_TUPLE is a 2-item array: |br|
+:samp:`[{MP_STR OPERATOR = '#', {MP_INT FIELD_NO = field number starting with 1}]`.
+Normally field numbers start with 1.
+
+If the operation specifies one value, then IPROTO_TUPLE is a 3-item array: |br|
+:samp:`[{MP_STR string OPERATOR = '+' or '-' or '^' or '^' or '|' or '!' or '='}, {MP_INT FIELD_NO}, {MP_OBJECT VALUE}]`. |br|
+
+Otherwise IPROTO_TUPLE is a 5-item array: |br|
+:samp:`[{MP_STR string OPERATOR = ':'}, {MP_INT integer FIELD_NO}, {MP_INT POSITION}, {MP_INT OFFSET}, {MP_STR VALUE}]`. |br|
+
+Example: if the id of 'tspace' is 512 and this is the fifth message, |br|
+:samp:`{conn}.`:code:`space.tspace:update(999, {{'=', 2, 'B'}})` will cause:
+
+..  code-block:: none
+
+    # <size>
+    msgpack(17)
+    # <header>
+    msgpack({
+        IPROTO_REQUEST_TYPE: IPROTO_UPDATE,
+        IPROTO_SYNC: 5
+    })
+    # <body> ... the map-item IPROTO_INDEX_BASE is optional
+    msgpack({
+        IPROTO_SPACE_ID: 512,
+        IPROTO_INDEX_ID: 0,
+        IPROTO_INDEX_BASE: 1,
+        IPROTO_TUPLE: [['=',2,'B']],
+        IPROTO_KEY: [999]
+    })
+
+Later in :ref:`Binary protocol -- illustration <box_protocol-illustration>`
+we will show actual byte codes of an IPROTO_UPDATE message.
+
+
+..  _box_protocol-delete:
+
+IPROTO_DELETE = 0x05
+~~~~~~~~~~~~~~~~~~~~
+
+See :ref:`space_object:delete()  <box_space-delete>`.
+The body is a 3-item map:
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <size>
+    msgpack(:samp:`{{MP_UINT unsigned integer = size(<header>) + size(<body>)}}`)
+    # <header>
+    msgpack({
+        IPROTO_REQUEST_TYPE: IPROTO_DELETE,
+        IPROTO_SYNC: :samp:`{{MP_UINT unsigned integer}}`
+    })
+    # <body>
+    msgpack({
+        IPROTO_SPACE_ID: :samp:`{{MP_UINT unsigned integer}}`,
+        IPROTO_INDEX_ID: :samp:`{{MP_UINT unsigned integer}}`,
+        IPROTO_KEY: :samp:`{{MP_ARRAY array of key values}}`
+    })
+
+
+..  _box_protocol-call16:
+
+IPROTO_CALL_16 = 0x06
+~~~~~~~~~~~~~~~~~~~~~
+
+See :ref:`conn:call() <net_box-call>`. The suffix ``_16`` is a hint that this is
+for the ``call()`` until Tarantool 1.6. It is deprecated.
+Use :ref:`IPROTO_CALL <box_protocol-call>` instead.
+The body is a 2-item map:
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <size>
+    msgpack(:samp:`{{MP_UINT unsigned integer = size(<header>) + size(<body>)}}`)
+    # <header>
+    msgpack({
+        IPROTO_REQUEST_TYPE: IPROTO_CALL_16,
+        IPROTO_SYNC: :samp:`{{MP_UINT unsigned integer}}`
+    })
+    # <body>
+    msgpack({
+        IPROTO_FUNCTION_NAME: :samp:`{{MP_STR string}}`,
+        IPROTO_TUPLE: :samp:`{{MP_ARRAY array of arguments}}`
+    })
+
+The return value is an array of tuples.
+
+
+..  _box_protocol-auth:
+
+IPROTO_AUTH = 0x07
+~~~~~~~~~~~~~~~~~~
+
+See :ref:`authentication <authentication-users>`.
+See the later section :ref:`Binary protocol -- authentication <box_protocol-authentication>`.
+
+
+..  _box_protocol-eval:
+
+IPROTO_EVAL = 0x08
+~~~~~~~~~~~~~~~~~~
+
+See :ref:`conn:eval() <net_box-eval>`.
+Since the argument is a Lua expression, this is
+Tarantool's way to handle non-binary with the
+binary protocol. Any request that does not have
+its own code, for example :samp:`box.space.{space-name}:drop()`,
+will be handled either with :ref:`IPROTO_CALL <box_protocol-call>`
+or IPROTO_EVAL.
+The :ref:`tarantoolctl <tarantoolctl>` administrative utility
+makes extensive use of ``eval``.
+The body is a 2-item map:
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <size>
+    msgpack(:samp:`{{MP_UINT unsigned integer = size(<header>) + size(<body>)}}`)
+    # <header>
+    msgpack({
+        IPROTO_REQUEST_TYPE: IPROTO_EVAL,
+        IPROTO_SYNC: :samp:`{{MP_UINT unsigned integer}}`
+    })
+    # <body>
+    msgpack({
+        IPROTO_EXPR: :samp:`{{MP_STR string}}`,
+        IPROTO_TUPLE: :samp:`{{MP_ARRAY array of arguments}}`
+    })
+
+Example: if this is the fifth message, :samp:`conn:eval('return 5;')` will cause:
+
+..  code-block:: none
+
+    # <size>
+    msgpack(19)
+    # <header>
+    msgpack({
+        IPROTO_SYNC: 5
+        IPROTO_REQUEST_TYPE: IPROTO_EVAL
+    })
+    # <body>
+    msgpack({
+        IPROTO_EXPR: 'return 5;',
+        IPROTO_TUPLE: []
+    })
+
+
+..  _box_protocol-upsert:
+
+IPROTO_UPSERT = 0x09
+~~~~~~~~~~~~~~~~~~~~
+
+See :ref:`space_object:upsert()  <box_space-upsert>`.
+
+The body is usually a 4-item map:
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <size>
+    msgpack(:samp:`{{MP_UINT unsigned integer = size(<header>) + size(<body>)}}`)
+    # <header>
+    msgpack({
+        IPROTO_REQUEST_TYPE: IPROTO_UPSERT,
+        IPROTO_SYNC: :samp:`{{MP_UINT unsigned integer}}`
+    })
+    # <body>
+    msgpack({
+        IPROTO_SPACE_ID: :samp:`{{MP_UINT unsigned integer}}`,
+        IPROTO_INDEX_BASE: :samp:`{{MP_UINT unsigned integer}}`,
+        IPROTO_OPS: :samp:`{{MP_ARRAY array of update operations}}`,
+        IPROTO_TUPLE: :samp:`{{MP_ARRAY array of primary-key field values}}`
+    })
+
+The IPROTO_OPS is the same as the IPROTO_TUPLE of :ref:`IPROTO_UPDATE <box_protocol-update>`.
+
+
+..  _box_protocol-call:
+
+IPROTO_CALL = 0x0a
+~~~~~~~~~~~~~~~~~~
+
+See :ref:`conn:call() <net_box-call>`.
+The body is a 2-item map:
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <size>
+    msgpack(:samp:`{{MP_UINT unsigned integer = size(<header>) + size(<body>)}}`)
+    # <header>
+    msgpack({
+        IPROTO_REQUEST_TYPE: IPROTO_CALL,
+        IPROTO_SYNC: :samp:`{{MP_UINT unsigned integer}}`
+    })
+    # <body>
+    msgpack({
+        IPROTO_FUNCTION_NAME: :samp:`{{MP_STR string}}`,
+        IPROTO_TUPLE: :samp:`{{MP_ARRAY array of arguments}}`
+    })
+
+The response will be a list of values, similar to the
+:ref:`IPROTO_EVAL <box_protocol-eval>` response.
+
+
+..  _box_protocol-execute:
+
+IPROTO_EXECUTE = 0x0b
+~~~~~~~~~~~~~~~~~~~~~
+
+See :ref:`box.execute() <box-sql_box_execute>`, this is only for SQL.
+The body is a 3-item map:
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <size>
+    msgpack(:samp:`{{MP_UINT unsigned integer = size(<header>) + size(<body>)}}`)
+    # <header>
+    msgpack({
+        IPROTO_REQUEST_TYPE: IPROTO_EXECUTE,
+        IPROTO_SYNC: :samp:`{{MP_UINT unsigned integer}}`
+    })
+    # <body>
+    msgpack({
+        IPROTO_STMT_ID: :samp:`{{MP_INT integer}}` or IPROTO_SQL_TEXT: :samp:`{{MP_STR string}}`,
+        IPROTO_SQL_BIND: :samp:`{{MP_INT integer}}`,
+        IPROTO_OPTIONS: :samp:`{{MP_ARRAY array}}`
+    })
+
+Use IPROTO_STMT_ID (0x43) and statement-id (MP_INT) if executing a prepared statement,
+or use
+IPROTO_SQL_TEXT (0x40) and statement-text (MP_STR) if executing an SQL string, then
+IPROTO_SQL_BIND (0x41) and array of parameter values to match ? placeholders or
+:name placeholders, IPROTO_OPTIONS (0x2b) and array of options (usually empty).
+
+For example, suppose we prepare a statement
+with two ? placeholders, and execute with two parameters, thus: |br|
+:code:`n = conn:prepare([[VALUES (?, ?);]])` |br|
+:code:`conn:execute(n.stmt_id, {1,'a'})` |br|
+Then the body will look like this:
+
+..  code-block:: none
+
+    # <body>
+    msgpack({
+        IPROTO_STMT_ID: 0xd7aa741b,
+        IPROTO_SQL_BIND: [1, 'a'],
+        IPROTO_OPTIONS: []
+    })
+
+Later in :ref:`Binary protocol -- illustration <box_protocol-illustration>`
+we will show actual byte codes of the IPROTO_EXECUTE message.
+
+To call a prepared statement with named parameters from a connector pass the
+parameters within an array of maps. A client should wrap each element into a map,
+where the key holds a name of the parameter (with a colon) and the value holds
+an actual value. So, to bind foo and bar to 42 and 43, a client should send
+``IPROTO_SQL_TEXT: <...>, IPROTO_SQL_BIND: [{"foo": 42}, {"bar": 43}]``.
+
+If a statement has both named and non-named parameters, wrap only named ones
+into a map. The rest of the parameters are positional and will be substituted in order.
+
+
+..  _box_protocol-nop:
+
+IPROTO_NOP = 0x0c
+~~~~~~~~~~~~~~~~~
+
+There is no Lua request exactly equivalent to IPROTO_NOP.
+It causes the LSN to be incremented.
+It could be sometimes used for updates where the old and new values
+are the same, but the LSN must be increased because a data-change
+must be recorded.
+The body is: nothing.
+
+
+..  _box_protocol-prepare:
+
+IPROTO_PREPARE = 0x0d
+~~~~~~~~~~~~~~~~~~~~~
+
+See :ref:`box.prepare <box-sql_box_prepare>`, this is only for SQL.
+The body is a 1-item map:
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <size>
+    msgpack(:samp:`{{MP_UINT unsigned integer = size(<header>) + size(<body>)}}`)
+    # <header>
+    msgpack({
+        IPROTO_REQUEST_TYPE: IPROTO_PREPARE,
+        IPROTO_SYNC: :samp:`{{MP_UINT unsigned integer}}`
+    })
+    # <body>
+    msgpack({
+        IPROTO_STMT_ID: :samp:`{{MP_INT integer}}` or IPROTO_SQL_TEXT: :samp:`{{MP_STR string}}`
+    })
+
+IPROTO_STMT_ID (0x43) and statement-id (MP_INT) if executing a prepared statement
+or
+IPROTO_SQL_TEXT (0x40) and statement-text (string) if executing an SQL string.
+Thus the IPROTO_PREPARE map item is the same as the first item of the
+:ref:`IPROTO_EXECUTE <box_protocol-execute>` body.
+
+..  _box_protocol-begin:
+
+IPROTO_BEGIN = 0x0e
+~~~~~~~~~~~~~~~~~~~
+
+Begin a transaction in the specified stream.
+See :ref:`stream:begin() <net_box-stream_begin>`.
+The body is optional and can contain two items:
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <size>
+    msgpack(:samp:`{{MP_UINT unsigned integer = size(<header>) + size(<body>)}}`)
+    # <header>
+    msgpack({
+        IPROTO_REQUEST_TYPE: IPROTO_BEGIN,
+        IPROTO_SYNC: :samp:`{{MP_UINT unsigned integer}}`,
+        IPROTO_STREAM_ID: :samp:`{{MP_UINT unsigned integer}}`
+    })
+    # <body>
+    msgpack({
+        IPROTO_TIMEOUT: :samp:`{{MP_DOUBLE}}`,
+        IPROTO_TXN_ISOLATION: :samp:`{{MP_UINT unsigned integer}}`
+    })
+
+IPROTO_TIMEOUT is an optional timeout (in seconds). After it expires,
+the transaction will be rolled back automatically.
+
+IPROTO_TXN_ISOLATION is the :ref:`transaction isolation level <txn_mode_mvcc-options>`.
+It can take the following values:
+
+- ``TXN_ISOLATION_DEFAULT = 0``	-- use the default level from ``box.cfg`` (default value)
+- ``TXN_ISOLATION_READ_COMMITTED = 1`` -- read changes that are committed but not confirmed yet
+- ``TXN_ISOLATION_READ_CONFIRMED = 2`` -- read confirmed changes
+- ``TXN_ISOLATION_BEST_EFFORT = 3`` -- determine isolation level automatically
+
+See :ref:`Binary protocol -- streams <box_protocol-streams>` to learn more about
+stream transactions in the binary protocol.
+
+..  _box_protocol-commit:
+
+IPROTO_COMMIT = 0x0f
+~~~~~~~~~~~~~~~~~~~~
+
+Commit the transaction in the specified stream.
+See :ref:`stream:commit() <net_box-stream_commit>`.
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <size>
+    msgpack(7)
+    # <header>
+    msgpack({
+        IPROTO_REQUEST_TYPE: IPROTO_COMMIT,
+        IPROTO_SYNC: :samp:`{{MP_UINT unsigned integer}}`,
+        IPROTO_STREAM_ID: :samp:`{{MP_UINT unsigned integer}}`
+    })
+
+See :ref:`Binary protocol -- streams <box_protocol-streams>` to learn more about
+stream transactions in the binary protocol.
+
+
+..  _box_protocol-rollback:
+
+IPROTO_ROLLBACK = 0x10
+~~~~~~~~~~~~~~~~~~~~~~
+
+Rollback the transaction in the specified stream.
+See :ref:`stream:rollback() <net_box-stream_rollback>`.
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <size>
+    msgpack(7)
+    # <header>
+    msgpack({
+        IPROTO_REQUEST_TYPE: IPROTO_ROLLBACK,
+        IPROTO_SYNC: :samp:`{{MP_UINT unsigned integer}}`,
+        IPROTO_STREAM_ID: :samp:`{{MP_UINT unsigned integer}}`
+    })
+
+See :ref:`Binary protocol -- streams <box_protocol-streams>` to learn more about
+stream transactions in the binary protocol.
+
+
+..  _box_protocol-ping:
+
+IPROTO_PING = 0x40
+~~~~~~~~~~~~~~~~~~
+
+See :ref:`conn:ping() <conn-ping>`. The body will be an empty map because IPROTO_PING
+in the header contains all the information that the server instance needs.
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <size>
+    msgpack(5)
+    # <header>
+    msgpack({
+        IPROTO_REQUEST_TYPE: IPROTO_PING,
+        IPROTO_SYNC: :samp:`{{MP_UINT unsigned integer}}`
+    })
+
+..  _box_protocol-join:
+
+..  code-block:: lua
+
+    IPROTO_JOIN = 0x41 -- for replication
+    IPROTO_SUBSCRIBE = 0x42 -- for replication SUBSCRIBE
+    IPROTO_VOTE_DEPRECATED = 0x43 -- for old style vote, superseded by IPROTO_VOTE
+    IPROTO_VOTE = 0x44 -- for master election
+    IPROTO_FETCH_SNAPSHOT = 0x45 -- for starting anonymous replication
+    IPROTO_REGISTER = 0x46 -- for leaving anonymous replication.
+
+Tarantool constants 0x41 to 0x46 (decimal 65 to 70) are for replication.
+Connectors and clients do not need to send replication packets.
+See :ref:`Binary protocol -- replication <box_protocol-replication>`.
+
+The next two IPROTO messages are used in replication connections between
+Tarantool nodes in :ref:`synchronous replication <repl_sync>`.
+The messages are not supposed to be used by any client applications in their
+regular connections.
+
+..  _box_protocol-raft_confirm:
+
+IPROTO_RAFT_CONFIRM = 0x28
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This message confirms that the transactions originated from the instance
+with id = IPROTO_REPLICA_ID have achieved quorum and can be committed,
+up to and including LSN = IPROTO_LSN.
+Prior to Tarantool :tarantool-release:`2.10.0`, IPROTO_RAFT_CONFIRM was called IPROTO_CONFIRM.
+
+The body is a 2-item map:
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <size>
+    msgpack(:samp:`{{MP_UINT unsigned integer = size(<header>) + size(<body>)}}`)
+    # <header>
+    msgpack({
+        IPROTO_REQUEST_TYPE: IPROTO_RAFT_CONFIRM,
+        IPROTO_SYNC: :samp:`{{MP_UINT unsigned integer}}`
+    })
+    # <body>
+    msgpack({
+        IPROTO_REPLICA_ID: :samp:`{{MP_INT integer}}`,
+        IPROTO_LSN: :samp:`{{MP_INT integer}}`
+    })
+
+
+..  _box_protocol-raft_rollback:
+
+IPROTO_RAFT_ROLLBACK = 0x29
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This message says that the transactions originated from the instance
+with id = IPROTO_REPLICA_ID couldn't achieve quorum for some reason
+and should be rolled back, down to LSN = IPROTO_LSN and including it.
+Prior to Tarantool version 2.10, IPROTO_RAFT_ROLLBACK was called IPROTO_ROLLBACK.
+
+The body is a 2-item map:
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <size>
+    msgpack(:samp:`{{MP_UINT unsigned integer = size(<header>) + size(<body>)}}`)
+    # <header>
+    msgpack({
+        IPROTO_REQUEST_TYPE: IPROTO_RAFT_ROLLBACK,
+        IPROTO_SYNC: :samp:`{{MP_UINT unsigned integer}}`
+    })
+    # <body>
+    msgpack({
+        IPROTO_REPLICA_ID: :samp:`{{MP_INT integer}}`,
+        IPROTO_LSN: :samp:`{{MP_INT integer}}`
+    })
+
+..  _box_protocol-id:
+
+IPROTO_ID = 0x49
+~~~~~~~~~~~~~~~~
+
+Clients send this message to inform the server about the protocol version and
+features they support. Based on this information, the server can enable or
+disable certain features in interacting with these clients.
+
+The body is a 2-item map:
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <size>
+    msgpack(:samp:`{{MP_UINT unsigned integer = size(<header>) + size(<body>)}}`)
+    # <header>
+    msgpack({
+        IPROTO_REQUEST_TYPE: IPROTO_ID,
+        IPROTO_SYNC: :samp:`{{MP_UINT unsigned integer}}`
+    })
+    # <body>
+    msgpack({
+        IPROTO_VERSION: :samp:`{{MP_UINT unsigned integer}}}`,
+        IPROTO_FEATURES: :samp:`{{MP_ARRAY array of unsigned integers}}}`
+    })
+
+IPROTO_VERSION is an integer number reflecting the version of protocol that the
+client supports. The latest IPROTO_VERSION is |iproto_version|.
+
+Available IPROTO_FEATURES are the following:
+
+- ``IPROTO_FEATURE_STREAMS = 0`` -- streams support: :ref:`IPROTO_STREAM_ID <box_protocol-iproto_stream_id>`
+  in the request header.
+- ``IPROTO_FEATURE_TRANSACTIONS = 1`` -- transaction support: IPROTO_BEGIN,
+  IPROTO_COMMIT, and IPROTO_ROLLBACK commands (with :ref:`IPROTO_STREAM_ID <box_protocol-iproto_stream_id>`
+  in the request header). Learn more about :ref:`sending transaction commands <box_protocol-stream_transactions>`.
+- ``IPROTO_FEATURE_ERROR_EXTENSION = 2`` -- :ref:`MP_ERROR <msgpack_ext-error>`
+  MsgPack extension support. Clients that don't support this feature will receive
+  error responses for :ref:`IPROTO_EVAL <box_protocol-eval>` and
+  :ref:`IPROTO_CALL <box_protocol-call>` encoded to string error messages.
+- ``IPROTO_FEATURE_WATCHERS = 3`` -- remote watchers support: :ref:`IPROTO_WATCH <box_protocol-watch>`,
+  :ref:`IPROTO_UNWATCH <box_protocol-unwatch>`, and :ref:`IPROTO_EVENT <box_protocol-event>` commands.
+
+IPROTO_ID requests can be processed without authentication.
+
+IPROTO_WATCH = 0x4a
+~~~~~~~~~~~~~~~~~~~
+
+See the :ref:`Watchers <box-protocol-watchers>` section below.
+
+IPROTO_UNWATCH = 0x4b
+~~~~~~~~~~~~~~~~~~~~~
+
+See the :ref:`Watchers <box-protocol-watchers>` section below.
+
+IPROTO_EVENT = 0x4c
+~~~~~~~~~~~~~~~~~~~
+
+See the :ref:`Watchers <box-protocol-watchers>` section below.
+
+
+..  _box-protocol-watchers:
+
+Watchers
+--------
+
+The commands below support asynchronous server-client notifications signalled
+with :ref:`box.broadcast() <box-broadcast>`.
+Servers that support the new feature set the ``IPROTO_FEATURE_WATCHERS`` feature in reply to the ``IPROTO_ID`` command.
+When the connection is closed, all watchers registered for it are unregistered.
+
+The remote :ref:`watcher <box-watchers>` protocol works in the following way:
+
+#.  The client sends an ``IPROTO_WATCH`` packet to subscribe to the updates of a specified key defined on the server.
+
+#.  The server sends an ``IPROTO_EVENT`` packet to the subscribed client after registration.
+    The packet contains the key name and its current value.
+    After that, the packet is sent every time the key value is updated with
+    ``box.broadcast()``, provided that the last notification was acknowledged (see below).
+
+#.  After receiving the notification, the client sends an ``IPROTO_WATCH`` packet to acknowledge the notification.
+
+#.  If the client doesn't want to receive any more notifications, it unsubscribes by sending
+    an ``IPROTO_UNWATCH`` packet.
+
+All the three request types are asynchronous -- the receiving end doesn't send a packet in reply to any of them.
+Therefore, neither of them has a sync number.
+
+..  _box_protocol-watch:
+
+IPROTO_WATCH = 0x4a
+~~~~~~~~~~~~~~~~~~~
+
+Registers a new watcher for the given notification key or confirms a notification if the watcher is
+already subscribed.
+The watcher is notified after registration.
+After that, the notification is sent every time the key is updated.
+The server doesn't reply to the request unless it fails to parse the packet.
+
+The body is a 2-item map:
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <size>
+    msgpack(:samp:`{{MP_UINT unsigned integer = size(<header>) + size(<body>)}}`)
+    # <header>
+    msgpack({
+        IPROTO_REQUEST_TYPE: IPROTO_WATCH
+    })
+    # <body>
+    msgpack({
+        IPROTO_EVENT_KEY: :samp:`{{MP_STR string}}}`
+    })
+
+``IPROTO_EVENT_KEY`` (code 0x56) contains the key name.
+
+..  _box_protocol-unwatch:
+
+IPROTO_UNWATCH = 0x4b
+~~~~~~~~~~~~~~~~~~~~~
+
+Unregisters a watcher subscribed to the given notification key.
+The server doesn't reply to the request unless it fails to parse the packet.
+
+The body is a 2-item map:
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <size>
+    msgpack(:samp:`{{MP_UINT unsigned integer = size(<header>) + size(<body>)}}`)
+    # <header>
+    msgpack({
+        IPROTO_REQUEST_TYPE: IPROTO_UNWATCH
+    })
+    # <body>
+    msgpack({
+        IPROTO_EVENT_KEY: :samp:`{{MP_STR string}}}`
+    })
+
+``IPROTO_EVENT_KEY`` (code 0x56) contains a key name.
+
+..  _box_protocol-event:
+
+IPROTO_EVENT = 0x4c
+~~~~~~~~~~~~~~~~~~~
+
+Sent by the server to notify a client about an update of a key.
+
+The body is a 2-item map:
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <size>
+    msgpack(:samp:`{{MP_UINT unsigned integer = size(<header>) + size(<body>)}}`)
+    # <header>
+    msgpack({
+        IPROTO_REQUEST_TYPE: IPROTO_EVENT
+    })
+    # <body>
+    msgpack({
+        IPROTO_EVENT_KEY: :samp:`{{MP_STR string}}}`,
+        IPROTO_EVENT_DATA: :samp:`{{MP_OBJECT value}}}`
+    })
+
+``IPROTO_EVENT_KEY`` (code 0x56) contains the key name.
+
+``IPROTO_EVENT_DATA`` (code 0x57) contains data sent to a remote watcher.
+The parameter is optional, the default value is ``nil``.
+
+..  _box_protocol-responses:
+
+Responses if no error and no SQL
+--------------------------------
+
+After the :ref:`header <box_protocol-header>`, for a response,
+there will be a body.
+If there was no error, it will contain IPROTO_OK (0x00).
+If there was an error, it will contain an error code other than IPROTO_OK.
+Responses to SQL statements are slightly different and will be described
+in the later section,
+:ref:`Binary protocol -- responses for SQL <box_protocol-sql_protocol>`.
+
+For IPROTO_OK, the header Response-Code-Indicator will be 0 and the body is a 1-item map.
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <size>
+    msgpack(:samp:`{{MP_UINT unsigned integer = size(<header>) + size(<body>)}}`)
+    # <header>
+    msgpack({
+        Response-Code-Indicator: IPROTO_OK,
+        IPROTO_SYNC: :samp:`{{MP_UINT unsigned integer, may be 64-bit}}`,
+        IPROTO_SCHEMA_VERSION: :samp:`{{MP_UINT unsigned integer}}`
+    })
+    # <body>
+    msgpack({
+        IPROTO_DATA: :samp:`{{any type}}`
+    })
+
+- For :ref:`IPROTO_PING <box_protocol-ping>` the body will be an empty map.
+
+- For most data-access requests (:ref:`IPROTO_SELECT <box_protocol-select>`,
+  :ref:`IPROTO_INSERT <box_protocol-insert>`, :ref:`IPROTO_DELETE <box_protocol-delete>`
+  , etc.) the body is an IPROTO_DATA map with an array of tuples that contain
+  an array of fields.
+
+- For :ref:`IPROTO_EVAL <box_protocol-eval>` and :ref:`IPROTO_CALL <box_protocol-call>`
+  it will usually be an array but, since Lua requests can result in a wide variety
+  of structures, bodies can have a wide variety of structures.
+
+- For :ref:`IPROTO_ID <box_protocol-id>`, the response body has the same structure as
+  the request body. It informs the client about the protocol version and features
+  that the server supports.
+
+Example: if this is the fifth message and the request is
+:codenormal:`box.space.`:codeitalic:`space-name`:codenormal:`:insert{6}`,
+and the previous schema version was 100,
+a successful response will look like this:
+
+..  code-block:: none
+
+    # <size>
+    msgpack(32)
+    # <header>
+    msgpack({
+        Response-Code-Indicator: IPROTO_OK,
+        IPROTO_SYNC: 5,
+        IPROTO_SCHEMA_VERSION: 100
+    })
+    # <body>
+    msgpack({
+        IPROTO_DATA: [[6]]
+    })
+
+Later in :ref:`Binary protocol -- illustration <box_protocol-illustration>`
+we will show actual byte codes of the response to the IPROTO_INSERT message.
+
+IPROTO_DATA is what we get with net_box and :ref:`Module buffer <buffer-module>`
+so if we were using net_box we could decode with
+:ref:`msgpack.decode_unchecked() <msgpack-decode_unchecked_string>`,
+or we could convert to a string with :samp:`ffi.string({pointer},{length})`.
+The :ref:`pickle.unpack() <pickle-unpack>` function might also be helpful.
+
+..  _box_protocol-responses_out_of_band:
+
+Responses for no error and out-of-band
+--------------------------------------
+
+If the response is out-of-band, due to use of
+:ref:`box.session.push() <box_session-push>`,
+then the header Response-Code-Indicator will be IPROTO_CHUNK instead of IPROTO_OK.
+
+..  _box_protocol-responses_error:
+
+Responses for errors
+--------------------
+
+For a response other than IPROTO_OK, the header Response-Code-Indicator will be
+``0x8XXX`` and the body will be a 1-item map.
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <size>
+    msgpack(32)
+    # <header>
+    msgpack({
+        Response-Code-Indicator: :samp:`{{0x8XXX}}`,
+        IPROTO_SYNC: :samp:`{{MP_UINT unsigned integer, may be 64-bit}}`,
+        IPROTO_SCHEMA_VERSION: :samp:`{{MP_UINT unsigned integer}}`
+    })
+    # <body>
+    msgpack({
+        IPROTO_ERROR: :samp:`{{MP_STRING string}}`
+    })
+
+where ``0x8XXX`` is the indicator for an error and ``XXX`` is a value in
+`src/box/errcode.h <https://github.com/tarantool/tarantool/blob/master/src/box/errcode.h>`_.
+``src/box/errcode.h`` also has some convenience macros which define hexadecimal
+constants for return codes.
+
+Example: in version 2.4.0 and earlier,
+if this is the fifth message and the request is to create a duplicate
+space with
+``conn:eval([[box.schema.space.create('_space');]])``
+the unsuccessful response will look like this:
+
+..  code-block:: none
+
+    # <size>
+    msgpack(32)
+    # <header>
+    msgpack({
+        Response-Code-Indicator: 0x800a,
+        IPROTO_SYNC: 5,
+        IPROTO_SCHEMA_VERSION: 0x78
+    })
+    # <body>
+    msgpack({
+        IPROTO_ERROR:  "Space '_space' already exists"
+    })
+
+Later in :ref:`Binary protocol -- illustration <box_protocol-illustration>`
+we will show actual byte codes of the response to the IPROTO_EVAL message.
+
+Looking in errcode.h we find that error code 0x0a (decimal 10) is
+ER_SPACE_EXISTS, and the string associated with ER_SPACE_EXISTS is
+"Space '%s' already exists".
+
+Since version :doc:`2.4.1 </release/2.4.1>`, responses for errors have extra information
+following what was described above. This extra information is given via
+MP_ERROR extension type. See details in :ref:`MessagePack extensions
+<msgpack_ext-error>` section.
+
+
+..  _box_protocol-sql_protocol:
+
+Responses for SQL
+-----------------
+
+After the :ref:`header <box_protocol-header>`, for a response to an SQL statement,
+there will be a body that is slightly different from the body for
+:ref:`Binary protocol -- responses if no error and no SQL <box_protocol-responses>`.
+
+If the SQL request is not SELECT or VALUES or PRAGMA, then the response body
+contains only IPROTO_SQL_INFO (0x42). Usually IPROTO_SQL_INFO is a map with only
+one item -- SQL_INFO_ROW_COUNT (0x00) -- which is the number of changed rows.
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <size>
+    msgpack(:samp:`{{MP_UINT unsigned integer = size(<header>) + size(<body>)}}`)
+    # <header>
+    msgpack({
+        Response-Code-Indicator: IPROTO_OK,
+        IPROTO_SYNC: :samp:`{{MP_UINT unsigned integer, may be 64-bit}}`,
+        IPROTO_SCHEMA_VERSION: :samp:`{{MP_UINT unsigned integer}}`
+    })
+    # <body>
+    msgpack({
+        IPROTO_SQL_INFO: {
+            SQL_INFO_ROW_COUNT: :samp:`{{MP_UINT}}`
+        }
+    })
+
+For example, if the request is
+:samp:`INSERT INTO {table-name} VALUES (1), (2), (3)`, then the response body
+contains an :samp:`IPROTO_SQL_INFO map with SQL_INFO_ROW_COUNT = 3`.
+:samp:`SQL_INFO_ROW_COUNT` can be 0 for statements that do not change rows,
+but can be 1 for statements that create new objects.
+
+The IPROTO_SQL_INFO map may contain a second item -- :samp:`SQL_INFO_AUTO_INCREMENT_IDS
+(0x01)` -- which is the new primary-key value (or values) for an INSERT in a table
+defined with PRIMARY KEY AUTOINCREMENT. In this case the MP_MAP will have two
+keys, and  one of the two keys will be 0x01: SQL_INFO_AUTO_INCREMENT_IDS, which
+is an array of unsigned integers.
+
+If the SQL statement is SELECT or VALUES or PRAGMA, the response contains:
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <size>
+    msgpack(32)
+    # <header>
+    msgpack({
+        Response-Code-Indicator: IPROTO_OK,
+        IPROTO_SYNC: :samp:`{{MP_UINT unsigned integer, may be 64-bit}}`,
+        IPROTO_SCHEMA_VERSION: :samp:`{{MP_UINT unsigned integer}}`
+    })
+    # <body>
+    msgpack({
+        IPROTO_METADATA: :samp:`{{array of column maps}}`,
+        IPROTO_DATA: :samp:`{{array of tuples}}`
+    })
+
+* :samp:`IPROTO_METADATA: {array of column maps}` = array of column maps, with each column map containing
+  at least IPROTO_FIELD_NAME (0x00) and MP_STR, and IPROTO_FIELD_TYPE (0x01) and MP_STR.
+  Additionally, if ``sql_full_metadata`` in the
+  :ref:`_session_settings <box_space-session_settings>` system space
+  is TRUE, then the array will have these additional column maps
+  which correspond to components described in the
+  :ref:`box.execute() <box-sql_if_full_metadata>` section:
+
+..  code-block:: none
+
+    IPROTO_FIELD_COLL (0x02) and MP_STR
+    IPROTO_FIELD_IS_NULLABLE (0x03) and MP_BOOL
+    IPROTO_FIELD_IS_AUTOINCREMENT (0x04) and MP_BOOL
+    IPROTO_FIELD_SPAN (0x05) and MP_STR or MP_NIL
+
+* :samp:`IPROTO_DATA:{array of tuples}` = the result set "rows".
+
+Example:
+If we ask for full metadata by saying |br|
+:code:`conn.space._session_settings:update('sql_full_metadata', {{'=', 'value', true}})` |br|
+and we select the two rows from a table named t1 that has columns named DD and Д, with |br|
+:code:`conn:execute([[SELECT dd, дд AS д FROM t1;]])` |br|
+we could get this response, in the body:
+
+..  code-block:: none
+
+    # <body>
+    msgpack({
+        IPROTO_METADATA: [
+            IPROTO_FIELD_NAME: 'DD',
+            IPROTO_FIELD_TYPE: 'integer',
+            IPROTO_FIELD_IS_NULLABLE: false,
+            IPROTO_FIELD_IS_AUTOINCREMENT: true,
+            IPROTO_FIELD_SPAN: nil,
+            IPROTO_FIELD_NAME: 'Д',
+            IPROTO_FIELD_TYPE: 'string',
+            IPROTO_FIELD_COLL: 'unicode',
+            IPROTO_FIELD_IS_NULLABLE: true,
+            IPROTO_FIELD_SPAN: 'дд'
+        ],
+        IPROTO_DATA: [
+            [1,'a'],
+            [2,'b']'
+        ]
+    })
+
+If instead we said |br|
+:code:`conn:prepare([[SELECT dd, дд AS д FROM t1;]])` |br|
+then we could get almost the same response, but there would
+be no IPROTO_DATA and there would be two additional items: |br|
+``34 00 = IPROTO_BIND_COUNT and MP_UINT = 0`` (there are no parameters to bind), |br|
+``33 90 = IPROTO_BIND_METADATA and MP_ARRAY, size 0`` (there are no parameters to bind).
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <body>
+    msgpack({
+        IPROTO_STMT_ID: :samp:`{{MP_UINT unsigned integer}}`,
+        IPROTO_BIND_COUNT: :samp:`{{MP_INT integer}}`,
+        IPROTO_BIND_METADATA: :samp:`{{array of parameter descriptors}}`,
+            IPROTO_METADATA: [
+                IPROTO_FIELD_NAME: 'DD',
+                IPROTO_FIELD_TYPE: 'integer',
+                IPROTO_FIELD_IS_NULLABLE: false
+                IPROTO_FIELD_IS_AUTOINCREMENT: true
+                IPROTO_FIELD_SPAN: nil,
+                IPROTO_FIELD_NAME: 'Д',
+                IPROTO_FIELD_TYPE: 'string',
+                IPROTO_FIELD_COLL: 'unicode',
+                IPROTO_FIELD_IS_NULLABLE: true,
+                IPROTO_FIELD_SPAN: 'дд'
+            ]
+        })
+
+Now read the source code file `net_box.c <https://github.com/tarantool/tarantool/blob/master/src/box/lua/net_box.c>`_
+where the function "decode_metadata_optional" is an example of how Tarantool
+itself decodes extra items.
+
+Later in :ref:`Binary protocol -- illustration <box_protocol-illustration>`
+we will show actual byte codes of responses to the above SQL messages.
+
+
+..  _box_protocol-authentication:
+
+Authentication
+--------------
+
+Greeting message
+~~~~~~~~~~~~~~~~
+
+When a client connects to the server instance, the instance responds with
+a 128-byte text greeting message, not in MsgPack format: |br|
+64-byte Greeting text line 1 |br|
+64-byte Greeting text line 2 |br|
+44-byte base64-encoded salt |br|
+20-byte NULL
+
+The greeting contains two 64-byte lines of ASCII text.
+Each line ends with a newline character (:code:`\n`). The first line contains
+the instance version and protocol type. The second line contains up to 44 bytes
+of base64-encoded random string, to use in the authentication packet, and ends
+with up to 23 spaces.
+
+Part of the greeting is a base64-encoded session salt -
+a random string which can be used for authentication. The maximum length of an encoded
+salt (44 bytes) is more than the amount necessary to create the authentication
+message. An excess is reserved for future authentication
+schemas.
+
+Authentication is optional -- if it is skipped, then the session user is ``'guest'``
+(the ``'guest'`` user does not need a password).
+
+If authentication is not skipped, then at any time an authentication packet
+can be prepared using the greeting, the user's name and password,
+and `sha-1 <https://en.wikipedia.org/wiki/SHA-1>`_ functions, as follows.
+
+..  code-block:: none
+
+    PREPARE SCRAMBLE:
+
+        size_of_encoded_salt_in_greeting = 44;
+        size_of_salt_after_base64_decode = 32;
+         /* sha1() will only use the first 20 bytes */
+        size_of_any_sha1_digest = 20;
+        size_of_scramble = 20;
+
+    prepare 'chap-sha1' scramble:
+
+        salt = base64_decode(encoded_salt);
+        step_1 = sha1(password);
+        step_2 = sha1(step_1);
+        step_3 = sha1(first_20_bytes_of_salt, step_2);
+        scramble = xor(step_1, step_3);
+        return scramble;
+
+IPROTO_AUTH = 0x07
+~~~~~~~~~~~~~~~~~~
+
+The client sends an authentication packet as an IPROTO_AUTH message:
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <size>
+    msgpack(:samp:`{{MP_UINT unsigned integer = size(<header>) + size(<body>)}}`)
+    # <header>
+    msgpack({
+        IPROTO_REQUEST_TYPE: IPROTO_AUTH,
+        IPROTO_SYNC: :samp:`{{MP_UINT unsigned integer, usually = 1}}`
+    })
+    # <body>
+    msgpack({
+        IPROTO_USER_NAME: :samp:`{{MP_STRING string <key>}}`,
+        IPROTO_TUPLE: ['chap-sha1', :samp:`{{MP_STRING 20-byte string}}`]
+    })
+
+:code:`<key>` holds the user name. :code:`<tuple>` must be an array of 2 fields:
+authentication mechanism ("chap-sha1" is the only supported mechanism right now)
+and scramble, encrypted according to the specified mechanism.
+
+The server instance responds to an authentication packet with a standard response with 0 tuples.
+
+To see how Tarantool handles this, look at
+`net_box.c <https://github.com/tarantool/tarantool/blob/master/src/box/lua/net_box.c>`_
+function ``netbox_encode_auth``.
+
+..  _box_protocol-streams:
+
+Binary protocol -- streams
+--------------------------
+
+The :ref:`Streams and interactive transactions <txn_mode_stream-interactive-transactions>`
+feature, which was added in Tarantool version
+:tarantool-release:`2.10.0`, allows two things:
+sequential processing and interleaving.
+
+Sequential processing:
+With streams there is a guarantee that the server instance will not
+handle the next request in a stream until it has completed the previous one.
+
+Interleaving:
+For example, a series of requests can include
+"begin for stream #1", "begin for stream #2",
+"insert for stream #1", "insert for stream #2", "delete
+for stream #1", "commit for stream #1", "rollback for stream #2".
+
+To make these things possible,
+the engine should be :ref:`vinyl <engines-vinyl>` or :ref:`memtx with mvcc <cfg_basic-memtx_use_mvcc_engine>`, and
+the client is responsible for ensuring that the stream identifier,
+unsigned integer :ref:`IPROTO_STREAM_ID <box_protocol-iproto_stream_id>`, is in the request header.
+IPROTO_STREAM_ID can be any positive 64-bit number, and should be unique for the connection.
+If IPROTO_STREAM_ID equals zero the server instance will ignore it.
+
+For example, suppose that the client has started a stream with
+the :ref:`net.box module <net_box-module>`
+
+..  code-block:: lua
+
+    net_box = require('net.box')
+    conn = net_box.connect('localhost:3302')
+    stream = conn:new_stream()
+
+At this point the stream object will look like a duplicate of
+the conn object, with just one additional member: ``stream_id``.
+Now, using stream instead of conn, the client sends two requests:
+
+..  code-block:: lua
+
+    stream.space.T:insert{1}
+    stream.space.T:insert{2}
+
+The header and body of these requests will be the same as in
+non-stream :ref:`IPROTO_INSERT <box_protocol-insert>` requests, except
+that the header will contain an additional item: IPROTO_STREAM_ID=0x0a
+with MP_UINT=0x01. It happens to equal 1 for this example because
+each call to conn:new_stream() assigns a new number, starting with 1.
+
+..  _box_protocol-stream_transactions:
+
+The client makes stream transactions by sending, in order:
+
+1. IPROTO_BEGIN with an optional transaction timeout in the IPROTO_TIMEOUT field of the request body.
+2. The transaction data-change and query requests.
+3. IPROTO_COMMIT or IPROTO_ROLLBACK.
+
+All these requests must contain the same IPROTO_STREAM_ID value.
+
+A rollback will happen automatically if
+a disconnect occurs or the transaction timeout expires before the commit is possible.
+
+Thus there are now multiple ways to do transactions:
+with ``net_box`` ``stream:begin()`` and ``stream:commit()`` or ``stream:rollback()``
+which cause IPROTO_BEGIN and IPROTO_COMMIT or IPROTO_ROLLBACK with
+the current value of stream.stream_id;
+with :ref:`box.begin() <box-begin>` and :ref:`box.commit() <box-commit>` or :ref:`box.rollback() <box-rollback>`;
+with SQL and :ref:`START TRANSACTION <sql_start_transaction>` and :ref:`COMMIT <sql_commit>` or :ref:`ROLLBACK <sql_rollback>`.
+An application can use any or all of these ways.
+
+..  _box_protocol-replication:
+
+Replication
+-----------
+
+IPROTO_JOIN = 0x41
+~~~~~~~~~~~~~~~~~~
+
+First you must send an initial IPROTO_JOIN request.
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <size>
+    msgpack(:samp:`{{MP_UINT unsigned integer = size(<header>) + size(<body>)}}`)
+    # <header>
+    msgpack({
+        IPROTO_REQUEST_TYPE: IPROTO_JOIN,
+        IPROTO_SYNC: :samp:`{{MP_UINT unsigned integer}}`
+    })
+    # <body>
+    msgpack({
+        IPROTO_INSTANCE_UUID: :samp:`{{uuid}}`
+    })
+
+Then the instance which you want to connect to will send its last SNAP file,
+by simply creating a number of INSERTs (with additional LSN and ServerID)
+(do not reply to this). Then that instance will send a vclock's MP_MAP and
+close a socket.
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <size>
+    msgpack(:samp:`{{MP_UINT unsigned integer = size(<header>) + size(<body>)}}`)
+    # <header>
+    msgpack({
+        Response-Code-Indicator: 0,
+        IPROTO_SYNC: :samp:`{{MP_UINT unsigned integer}}`
+    })
+    # <body>
+    msgpack({
+        IPROTO_VCLOCK: :samp:`{{MP_INT SRV_ID, MP_INT SRV_LSN}}`
+    })
+
+IPROTO_SUBSCRIBE = 0x42
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Then you must send an IPROTO_SUBSCRIBE request.
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <size>
+    msgpack(:samp:`{{MP_UINT unsigned integer = size(<header>) + size(<body>)}}`)
+    # <header>
+    msgpack({
+        IPROTO_REQUEST_TYPE: IPROTO_SUBSCRIBE,
+        IPROTO_SYNC: :samp:`{{MP_UINT unsigned integer}}`,
+        IPROTO_INSTANCE_UUID: :samp:`{{uuid}}`,
+        IPROTO_CLUSTER_UUID: :samp:`{{uuid}}`,
+    })
+    # <body>
+    msgpack({
+        IPROTO_VCLOCK: :samp:`{{MP_INT SRV_ID, MP_INT SRV_LSN}}`
+    })
+
+Then you must process every request that could come through other masters.
+Every request between masters will have additional LSN and SERVER_ID.
+
+
+..  _box_protocol-heartbeat:
+
+HEARTBEATS
+~~~~~~~~~~
+
+Frequently a master sends a :ref:`heartbeat <heartbeat>` message to a replica.
+For example, if there is a replica with id = 2,
+and a timestamp with a moment in 2020, a master might send this:
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <header>
+    msgpack({
+        IPROTO_REQUEST_TYPE: 0
+        IPROTO_REPLICA_ID: 2
+        IPROTO_TIMESTAMP: :samp:`{{Float 64 MP_DOUBLE 8-byte timestamp}}`
+    })
+
+and the replica might send back this:
+
+..  code-block:: none
+
+    # <header>
+    msgpack({
+        Response-Code-Indicator: IPROTO_OK
+        IPROTO_REPLICA_ID: 2
+        IPROTO_VCLOCK: {1, 6}
+    })
+
+Later in :ref:`Binary protocol -- illustration <box_protocol-illustration>`
+we will show actual byte codes of the above heartbeat examples.
+
+..  _box_protocol-ballots:
+
+BALLOTS
+~~~~~~~
+
+While connecting for replication, an instance sends a request with header IPROTO_VOTE (0x44).
+The normal response is ER_OK,and IPROTO_BALLOT (0x29).
+The fields within IPROTO_BALLOT are map items:
+
+..  code-block:: none
+
+    IPROTO_BALLOT_IS_RO_CFG (0x01) + MP_BOOL
+    IPROTO_BALLOT_VCLOCK (0x02) + vclock
+    IPROTO_BALLOT_GC_VCLOCK (0x03) + vclock
+    IPROTO_BALLOT_IS_RO (0x04) + MP_BOOL
+    IPROTO_BALLOT_IS_ANON = 0x05 + MP_BOOL
+    IPROTO_BALLOT_IS_BOOTED = 0x06 + MP_BOOL
+    IPROTO_BALLOT_CAN_LEAD = 0x07 + MP_BOOL
+
+
+IPROTO_BALLOT_IS_RO_CFG and IPRO_BALLOT_VCLOCK and IPROTO_BALLOT_GC_VCLOCK and IPROTO_BALLOT_IS_RO
+were added in version :doc:`2.6.1 </release/2.6.1>`.
+IPROTO_BALLOT_IS_ANON was added in version :doc:`2.7.1 </release/2.7.1>`.
+IPROTO_BALLOT_IS_BOOTED was added in version 2.7.3 and 2.8.2 and 2.9.1.
+There have been some name changes starting with version 2.7.3 and 2.8.2 and 2.9.1:
+IPROTO_BALLOT_IS_RO_CFG was formerly called IPROTO_BALLOT_IS_RO,
+and IPROTO_BALLOT_IS_RO was formerly called IPROTO_BALLOT_IS_LOADING.
+
+IPROTO_BALLOT_IS_RO_CFG corresponds to :ref:`box.cfg.read_only <cfg_basic-read_only>`.
+
+IPROTO_BALLOT_GC_VCLOCK can be the vclock value of the instance's oldest
+WAL entry, which corresponds to :ref:`box.info.gc().vclock <box_info_gc>`.
+
+IPROTO_BALLOT_IS_RO is true if the instance is not writable,
+which may happen for a variety of reasons, such as:
+it was configured as :ref:`read_only <cfg_basic-read_only>`,
+or it has :ref:`orphan status <replication-orphan_status>`,
+or it is a :ref:`Raft <repl_leader_elect>` follower.
+
+IPROTO_BALLOT_IS_ANON corresponds to :ref:`box.cfg.replication_anon <cfg_replication-replication_anon>`.
+
+IPROTO_BALLOT_IS_BOOTED is true if the instance has finished its
+bootstrap or recovery process.
+
+IPROTO_BALLOT_CAN_LEAD is true if the :ref:`election_mode <cfg_replication-election_mode>`
+configuration setting is either 'candidate' or 'manual', so that
+during the :ref:`leader election process <repl_leader_elect_process>`
+this instance may be preferred over instances whose configuration
+setting is 'voter'.
+IPROTO_BALLOT_CAN_LEAD support was added simultaneously in
+version :doc:`2.7.3 </release/2.7.3>`
+and version :doc:`2.8.2 </release/2.8.2>`.
+
+..  _box_protocol-flags:
+
+FLAGS
+~~~~~
+
+For replication of :doc:`synchronous transactions </book/replication/repl_sync>`
+a header may contain a key = IPROTO_FLAGS and an MP_UINT value = one or more
+bits: IPROTO_FLAG_COMMIT or IPROTO_FLAG_WAIT_SYNC or IPROTO_FLAG_WAIT_ACK.
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <size>
+    msgpack(:samp:`{{MP_UINT unsigned integer = size(<header>) + size(<body>)}}`)
+    # <header>
+    msgpack({
+        # ... other header items ...,
+        IPROTO_FLAGS: :samp:`{{MP_UINT unsigned integer}}`
+    })
+    # <body>
+    msgpack({
+        # ... message for a transaction ...
+    })
+
+IPROTO_FLAG_COMMIT (0x01) will be set if this is the last message for a transaction,
+IPROTO_FLAG_WAIT_SYNC (0x02) will be set if this is the last message for a transaction which cannot be completed immediately,
+IPROTO_FLAG_WAIT_ACK (0x04) will be set if this is the last message for a synchronous transaction.
+
+..  _box_protocol-raft:
+
+IPROTO_RAFT = 0x1e
+~~~~~~~~~~~~~~~~~~
+
+A node broadcasts the IPROTO_RAFT request to all the replicas connected to it when the RAFT state of the node changes.
+It can be any actions changing the state, like starting a new election, bumping the term, voting for another node, becoming the leader, and so on.
+
+If there should be a response, for example, in case of a vote request to other nodes, the response will also be an IPROTO_RAFT message.
+In this case, the node should be connected as a replica to another node from which the response is expected because the response is sent via the replication channel.
+In other words, there should be a full-mesh connection between the nodes.
+
+..  cssclass:: highlight
+..  parsed-literal::
+
+    # <size>
+    msgpack(:samp:`{{MP_UINT unsigned integer = size(<header>) + size(<body>)}}`)
+    # <header>
+    msgpack({
+        IPROTO_REQUEST_TYPE: IPROTO_RAFT,
+        IPROTO_REPLICA_ID: :samp:`{{MP_INT integer}}`,  # ID of the replica which the request came from
+
+    })
+    # <body>
+    msgpack({
+        IPROTO_RAFT_TERM: :samp:`{{MP_UINT unsigned integer}}`,     # RAFT term of the instance
+        IPROTO_RAFT_VOTE: :samp:`{{MP_UINT unsigned integer}}`,     # Instance vote in the current term (if any).
+        IPROTO_RAFT_STATE: :samp:`{{MP_UINT unsigned integer}}`,    # Instance state. Possible values: 1 -- follower, 2 -- candidate, 3 -- leader.
+        IPROTO_RAFT_VCLOCK: :samp:`{{MP_ARRAY {{MP_INT SRV_ID, MP_INT SRV_LSN}, {MP_INT SRV_ID, MP_INT SRV_LSN}, ...}}}`,   # Current vclock of the instance. Presents only on the instances in the "candidate" state (IPROTO_RAFT_STATE == 2).
+        IPROTO_RAFT_LEADER_ID: :samp:`{{MP_UINT unsigned integer}}`,     # Current leader node ID as seen by the node that issues the request. Since version :doc:`2.10.0 </release/2.10.0>`.
+        IPROTO_RAFT_IS_LEADER_SEEN: :samp:`{{MP_BOOL boolean}}`     # Shows whether the node has a direct connection to the leader node. Since version :doc:`2.10.0 </release/2.10.0>`.
+
+    })
+
+..  _box_protocol-illustration:
+
+Examples
+--------
+
+
+To follow the examples in this section,
+get a single Linux computer and start three command-line shells ("terminals").
+
+-- On terminal #1, Start monitoring port 3302 with `tcpdump <https://www.tcpdump.org/manpages/tcpdump.1.html>`_: |br|
+
+..  code-block:: bash
+
+    sudo tcpdump -i lo 'port 3302' -X
+
+On terminal #2, start a server with:
+
+..  code-block:: lua
+
+    box.cfg{listen=3302}
+    box.schema.space.create('tspace')
+    box.space.tspace:create_index('I')
+    box.space.tspace:insert{280}
+    box.schema.user.grant('guest','read,write,execute,create,drop','universe')
+
+On terminal #3, start another server, which will act as a client, with:
+
+..  code-block:: lua
+
+    box.cfg{}
+    net_box = require('net.box')
+    conn = net_box.connect('localhost:3302')
+    conn.space.tspace:select(280)
+
+Now look at what tcpdump shows for the job connecting to 3302 -- the "request".
+After the words "length 32" is a packet that ends with these 32 bytes
+(we have added indented comments):
+
+..  code-block:: none
+
+    ce 00 00 00 1b   MP_UINT = decimal 27 = number of bytes after this
+    82               MP_MAP, size 2 (we'll call this "Main-Map")
+    01                 IPROTO_SYNC (Main-Map Item#1)
+    04                 MP_INT = 4 = number that gets incremented with each request
+    00                 IPROTO_REQUEST_TYPE (Main-Map Item#2)
+    01                 IPROTO_SELECT
+    86                 MP_MAP, size 6 (we'll call this "Select-Map")
+    10                   IPROTO_SPACE_ID (Select-Map Item#1)
+    cd 02 00             MP_UINT = decimal 512 = id of tspace (could be larger)
+    11                   IPROTO_INDEX_ID (Select-Map Item#2)
+    00                   MP_INT = 0 = id of index within tspace
+    14                   IPROTO_ITERATOR (Select-Map Item#3)
+    00                   MP_INT = 0 = Tarantool iterator_type.h constant ITER_EQ
+    13                   IPROTO_OFFSET (Select-Map Item#4)
+    00                   MP_INT = 0 = amount to offset
+    12                   IPROTO_LIMIT (Select-Map Item#5)
+    ce ff ff ff ff       MP_UINT = 4294967295 = biggest possible limit
+    20                   IPROTO_KEY (Select-Map Item#6)
+    91                   MP_ARRAY, size 1 (we'll call this "Key-Array")
+    cd 01 18               MP_UINT = 280 (Select-Map Item#6, Key-Array Item#1)
+                           -- 280 is the key value that we are searching for
+
+Now read the source code file
+`net_box.c <https://github.com/tarantool/tarantool/blob/master/src/box/lua/net_box.c>`_
+and skip to the line ``netbox_encode_select(lua_State *L)``.
+From the comments and from simple function calls like
+``mpstream_encode_uint(&stream, IPROTO_SPACE_ID);``
+you will be able to see how net_box put together the packet contents that you
+have just observed with tcpdump.
+
+There are libraries for reading and writing MessagePack objects.
+C programmers sometimes include `msgpuck.h <https://github.com/rtsisyk/msgpuck>`_.
+
+Now you know how Tarantool itself makes requests with the binary protocol.
+When in doubt about a detail, consult ``net_box.c`` -- it has routines for each
+request. Some :ref:`connectors <index-box_connectors>` have similar code.
+
+For an IPROTO_UPDATE example, suppose a user changes field #2 in tuple #2
+in space #256 to ``'BBBB'``. The body will look like this:
+(notice that in this case there is an extra map item
+IPROTO_INDEX_BASE, to emphasize that field numbers
+start with 1, which is optional and can be omitted):
+
+..  code-block:: none
+
+    04               IPROTO_UPDATE
+    85               IPROTO_MAP, size 5
+    10                 IPROTO_SPACE_ID, Map Item#1
+    cd 02 00           MP_UINT 256
+    11                 IPROTO_INDEX_ID, Map Item#2
+    00                 MP_INT 0 = primary-key index number
+    15                 IPROTO_INDEX_BASE, Map Item#3
+    01                 MP_INT = 1 i.e. field numbers start at 1
+    21                 IPROTO_TUPLE, Map Item#4
+    91                 MP_ARRAY, size 1, for array of operations
+    93                   MP_ARRAY, size 3
+    a1 3d                   MP_STR = OPERATOR = '='
+    02                      MP_INT = FIELD_NO = 2
+    a5 42 42 42 42 42       MP_STR = VALUE = 'BBBB'
+    20                 IPROTO_KEY, Map Item#5
+    91                 MP_ARRAY, size 1, for array of key values
+    02                   MP_UINT = primary-key value = 2
+
+Byte codes for the :ref:`IPROTO_EXECUTE <box_protocol-execute>` example:
+
+..  code-block:: none
+
+    0b               IPROTO_EXECUTE
+    83               MP_MAP, size 3
+    43                 IPROTO_STMT_ID Map Item#1
+    ce d7 aa 74 1b     MP_UINT value of n.stmt_id
+    41                 IPROTO_SQL_BIND Map Item#2
+    92                 MP_ARRAY, size 2
+    01                   MP_INT = 1 = value for first parameter
+    a1 61                MP_STR = 'a' = value for second parameter
+    2b                 IPROTO_OPTIONS Map Item#3
+    90                 MP_ARRAY, size 0 (there are no options)
+
+Byte codes for the response to the :codenormal:`box.space.`:codeitalic:`space-name`:codenormal:`:insert{6}`
+example:
+
+..  code-block:: none
+
+    ce 00 00 00 20                MP_UINT = HEADER AND BODY SIZE
+    83                            MP_MAP, size 3
+    00                              Response-Code-Indicator
+    ce 00 00 00 00                  MP_UINT = IPROTO_OK
+    01                              IPROTO_SYNC
+    cf 00 00 00 00 00 00 00 53      MP_UINT = sync value
+    05                              IPROTO_SCHEMA_VERSION
+    ce 00 00 00 68                  MP_UINT = schema version
+    81                            MP_MAP, size 1
+    30                              IPROTO_DATA
+    dd 00 00 00 01                  MP_ARRAY, size 1 (row count)
+    91                              MP_ARRAY, size 1 (field count)
+    06                              MP_INT = 6 = the value that was inserted
+
+Byte codes for the response to the ``conn:eval([[box.schema.space.create('_space');]])``
+example:
+
+..  code-block:: none
+
+    ce 00 00 00 3b                  MP_UINT = HEADER AND BODY SIZE
+    83                              MP_MAP, size 3 (i.e. 3 items in header)
+       00                              Response-Code-Indicator
+       ce 00 00 80 0a                  MP_UINT = hexadecimal 800a
+       01                              IPROTO_SYNC
+       cf 00 00 00 00 00 00 00 26      MP_UINT = sync value
+       05                              IPROTO_SCHEMA_VERSION
+       ce 00 00 00 78                  MP_UINT = schema version value
+       81                              MP_MAP, size 1
+         31                              IPROTO_ERROR_24
+         db 00 00 00 1d 53 70 61 63 etc. MP_STR = "Space '_space' already exists"
+
+Byte codes, if we use the same net.box connection that
+we used for :ref:`Binary protocol -- illustration <box_protocol-illustration>`
+and we say |br|
+``conn:execute([[CREATE TABLE t1 (dd INT PRIMARY KEY AUTOINCREMENT, дд STRING COLLATE "unicode");]])`` |br|
+``conn:execute([[INSERT INTO t1 VALUES (NULL, 'a'), (NULL, 'b');]])`` |br|
+and we watch what tcpdump displays, we will see two noticeable things:
+(1) the CREATE statement caused a schema change so the response has
+a new IPROTO_SCHEMA_VERSION value and the body includes
+the new contents of some system tables (caused by requests from net.box which users will not see);
+(2) the final bytes of the response to the INSERT will be:
+
+..  code-block:: none
+
+    81   MP_MAP, size 1
+    42     IPROTO_SQL_INFO
+    82     MP_MAP, size 2
+    00       Tarantool constant (not in iproto_constants.h) = SQL_INFO_ROW_COUNT
+    02       1 = row count
+    01       Tarantool constant (not in iproto_constants.h) = SQL_INFO_AUTOINCREMENT_ID
+    92       MP_ARRAY, size 2
+    01         first autoincrement number
+    02         second autoincrement number
+
+Byte codes for the SQL SELECT example,
+if we ask for full metadata by saying |br|
+:code:`conn.space._session_settings:update('sql_full_metadata', {{'=', 'value', true}})` |br|
+and we select the two rows from the table that we just created |br|
+:code:`conn:execute([[SELECT dd, дд AS д FROM t1;]])` |br|
+then tcpdump will show this response, after the header:
+
+..  code-block:: none
+
+    82                       MP_MAP, size 2 (i.e. metadata and rows)
+    32                         IPROTO_METADATA
+    92                         MP_ARRAY, size 2 (i.e. 2 columns)
+    85                           MP_MAP, size 5 (i.e. 5 items for column#1)
+    00 a2 44 44                    IPROTO_FIELD_NAME and 'DD'
+    01 a7 69 6e 74 65 67 65 72     IPROTO_FIELD_TYPE and 'integer'
+    03 c2                          IPROTO_FIELD_IS_NULLABLE and false
+    04 c3                          IPROTO_FIELD_IS_AUTOINCREMENT and true
+    05 c0                          PROTO_FIELD_SPAN and nil
+    85                           MP_MAP, size 5 (i.e. 5 items for column#2)
+    00 a2 d0 94                    IPROTO_FIELD_NAME and 'Д' upper case
+    01 a6 73 74 72 69 6e 67        IPROTO_FIELD_TYPE and 'string'
+    02 a7 75 6e 69 63 6f 64 65     IPROTO_FIELD_COLL and 'unicode'
+    03 c3                          IPROTO_FIELD_IS_NULLABLE and true
+    05 a4 d0 b4 d0 b4              IPROTO_FIELD_SPAN and 'дд' lower case
+    30                         IPROTO_DATA
+    92                         MP_ARRAY, size 2
+    92                           MP_ARRAY, size 2
+    01                             MP_INT = 1 i.e. contents of row#1 column#1
+    a1 61                          MP_STR = 'a' i.e. contents of row#1 column#2
+    92                           MP_ARRAY, size 2
+    02                             MP_INT = 2 i.e. contents of row#2 column#1
+    a1 62                          MP_STR = 'b' i.e. contents of row#2 column#2
+
+Byte code for the SQL PREPARE example. If we said |br|
+:code:`conn:prepare([[SELECT dd, дд AS д FROM t1;]])` |br|
+then tcpdump would show almost the same response, but there would
+be no IPROTO_DATA. Instead, additional items will appear:
+
+..  code-block:: none
+
+    34                       IPROTO_BIND_COUNT
+    00                       MP_UINT = 0
+
+    33                       IPROTO_BIND_METADATA
+    90                       MP_ARRAY, size 0
+
+``MP_UINT = 0`` and ``MP_ARRAY`` has size 0 because there are no parameters to bind.
+Full output:
+
+..  code-block:: none
+
+    84                       MP_MAP, size 4
+    43                         IPROTO_STMT_ID
+    ce c2 3c 2c 1e             MP_UINT = statement id
+    34                         IPROTO_BIND_COUNT
+    00                         MP_INT = 0 = number of parameters to bind
+    33                         IPROTO_BIND_METADATA
+    90                         MP_ARRAY, size 0 = there are no parameters to bind
+    32                         IPROTO_METADATA
+    92                         MP_ARRAY, size 2 (i.e. 2 columns)
+    85                           MP_MAP, size 5 (i.e. 5 items for column#1)
+    00 a2 44 44                    IPROTO_FIELD_NAME and 'DD'
+    01 a7 69 6e 74 65 67 65 72     IPROTO_FIELD_TYPE and 'integer'
+    03 c2                          IPROTO_FIELD_IS_NULLABLE and false
+    04 c3                          IPROTO_FIELD_IS_AUTOINCREMENT and true
+    05 c0                          PROTO_FIELD_SPAN and nil
+    85                           MP_MAP, size 5 (i.e. 5 items for column#2)
+    00 a2 d0 94                    IPROTO_FIELD_NAME and 'Д' upper case
+    01 a6 73 74 72 69 6e 67        IPROTO_FIELD_TYPE and 'string'
+    02 a7 75 6e 69 63 6f 64 65     IPROTO_FIELD_COLL and 'unicode'
+    03 c3                          IPROTO_FIELD_IS_NULLABLE and true
+    05 a4 d0 b4 d0 b4              IPROTO_FIELD_SPAN and 'дд' lower case
+
+Byte code for the heartbeat example. The master might send this body:
+
+..  code-block:: none
+
+    83                      MP_MAP, size 3
+    00                        Main-Map Item #1 IPROTO_REQUEST_TYPE
+    00                          MP_UINT = 0
+    02                        Main-Map Item #2 IPROTO_REPLICA_ID
+    02                          MP_UINT = 2 = id
+    04                        Main-Map Item #3 IPROTO_TIMESTAMP
+    cb                          MP_DOUBLE (MessagePack "Float 64")
+    41 d7 ba 06 7b 3a 03 21     8-byte timestamp
+
+Byte code for the heartbeat example. The replica might send back this body
+
+..  code-block:: none
+
+    81                       MP_MAP, size 1
+    00                         Main-Map Item #1 Response-code-indicator
+    00                         MP_UINT = 0 = IPROTO_OK
+    81                         Main-Map Item #2, MP_MAP, size 1
+    26                           Sub-Map Item #1 IPROTO_VCLOCK
+    81                           Sub-Map Item #2, MP_MAP, size 1
+    01                             MP_UINT = 1 = id (part 1 of vclock)
+    06                             MP_UINT = 6 = lsn (part 2 of vclock)
+
+
+
+..  _box_protocol-xlog:
+
+XLOG / SNAP
+-----------
+
+.xlog and .snap files have nearly the same format. The header looks like:
+
+..  code-block:: none
+
+    <type>\n                  SNAP\n or XLOG\n
+    <version>\n               currently 0.13\n
+    Server: <server_uuid>\n   where UUID is a 36-byte string
+    VClock: <vclock_map>\n    e.g. {1: 0}\n
+    \n
+
+After the file header come the data tuples.
+Tuples begin with a row marker ``0xd5ba0bab`` and
+the last tuple may be followed by an EOF marker
+``0xd510aded``.
+Thus, between the file header and the EOF marker, there
+may be data tuples that have this form:
+
+..  code-block:: none
+
+    0            3 4                                         17
+    +-------------+========+============+===========+=========+
+    |             |        |            |           |         |
+    | 0xd5ba0bab  | LENGTH | CRC32 PREV | CRC32 CUR | PADDING |
+    |             |        |            |           |         |
+    +-------------+========+============+===========+=========+
+       MP_FIXEXT2    MP_INT     MP_INT       MP_INT      ---
+
+    +============+ +===================================+
+    |            | |                                   |
+    |   HEADER   | |                BODY               |
+    |            | |                                   |
+    +============+ +===================================+
+         MP_MAP                     MP_MAP
+
+See the example in the :ref:`File formats <internals-data_persistence>` section.

--- a/source/conf.py
+++ b/source/conf.py
@@ -43,6 +43,13 @@ extensions = [
     'sphinx.ext.intersphinx',
 ]
 
+extlinks = {
+    'tarantool-issue': ('https://github.com/tarantool/tarantool/issues/%s', 'gh-'),
+    'tarantool-release': ('https://github.com/tarantool/tarantool/releases/%s', 'v. '),
+    'doc-issue': ('https://github.com/tarantool/doc/issues/%s', 'doc-'),
+}
+
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -168,6 +168,17 @@ texinfo_documents = [
      'Miscellaneous'),
 ]
 
+# Tarantool has extended Sphinx so that there are four new roles:
+# * :codenormal:`text`     displays text as monospace
+# * :codebold:`text`       displays text as monospace bold
+# * :codeitalic:`text`     displays text as monospace italic
+# * :codebolditalic:`text` displays text as monospace italic bold
+#
+# The effect on HTML output is defined in _static/css/theme_overrides.css.
+
+with open('./prolog.rst', 'r') as prolog:
+    rst_prolog = prolog.read()
+
 # -- Mapping for Intersphinx -------------------------------------------------
 
 intersphinx_mapping = {

--- a/source/file_formats.rst
+++ b/source/file_formats.rst
@@ -1,0 +1,130 @@
+..  _internals-data_persistence:
+
+File formats
+============
+
+..  _internals-wal:
+
+Data persistence and the WAL file format
+----------------------------------------
+
+To maintain data persistence, Tarantool writes each data change request (insert,
+update, delete, replace, upsert) into a write-ahead log (WAL) file in the
+:ref:`wal_dir <cfg_basic-wal_dir>` directory. A new WAL file is created for every
+:ref:`rows_per_wal <cfg_binary_logging_snapshots-rows_per_wal>` records, or for every
+:ref:`wal_max_size <cfg_binary_logging_snapshots-wal_max_size>` bytes.
+Each data change request gets assigned a continuously growing 64-bit log sequence
+number. The name of the WAL file is based on the log sequence number of the first
+record in the file, plus an extension ``.xlog``.
+
+Apart from a log sequence number and the data change request (formatted as in
+:ref:`Tarantool's binary protocol <internals-box_protocol>`),
+each WAL record contains a header, some metadata, and then the data formatted
+according to `msgpack <https://en.wikipedia.org/wiki/MessagePack>`_ rules.
+For example, this is what the WAL file looks like after the first INSERT request
+("s:insert({1})") for the sandbox database created in our
+:ref:`"Getting started" exercises <getting_started>`.
+On the left are the hexadecimal bytes that you would see with:
+
+..  code-block:: console
+
+    $ hexdump 00000000000000000000.xlog
+
+and on the right are comments.
+
+..  code-block:: none
+
+    Hex dump of WAL file       Comment
+    --------------------       -------
+    58 4c 4f 47 0a             "XLOG\n"
+    30 2e 31 33 0a             "0.13\n" = version
+    53 65 72 76 65 72 3a 20    "Server: "
+    38 62 66 32 32 33 65 30 2d [Server UUID]\n
+    36 39 31 34 2d 34 62 35 35
+    2d 39 34 64 32 2d 64 32 62
+    36 64 30 39 62 30 31 39 36
+    0a
+    56 43 6c 6f 63 6b 3a 20    "Vclock: "
+    7b 7d                      "{}" = vclock value, initially blank
+    ...                        (not shown = tuples for system spaces)
+    d5 ba 0b ab                Magic row marker always = 0xab0bbad5
+    19                         Length, not including length of header, = 25 bytes
+    00                           Record header: previous crc32
+    ce 8c 3e d6 70               Record header: current crc32
+    a7 cc 73 7f 00 00 66 39      Record header: padding
+    84                         msgpack code meaning "Map of 4 elements" follows
+    00 02                         element#1: tag=request type, value=0x02=IPROTO_INSERT
+    02 01                         element#2: tag=server id, value=0x01
+    03 04                         element#3: tag=lsn, value=0x04
+    04 cb 41 d4 e2 2f 62 fd d5 d4 element#4: tag=timestamp, value=an 8-byte "Float64"
+    82                         msgpack code meaning "map of 2 elements" follows
+    10 cd 02 00                   element#1: tag=space id, value=512, big byte first
+    21 91 01                      element#2: tag=tuple, value=1-element fixed array={1}
+
+Tarantool processes requests atomically: a change is either accepted and recorded
+in the WAL, or discarded completely. Let's clarify how this happens, using the
+REPLACE request as an example:
+
+1.  The server instance attempts to locate the original tuple by primary key. If found, a
+    reference to the tuple is retained for later use.
+
+2.  The new tuple is validated. If for example it does not contain an indexed
+    field, or it has an indexed field whose type does not match the type
+    according to the index definition, the change is aborted.
+
+3.  The new tuple replaces the old tuple in all existing indexes.
+
+4.  A message is sent to the WAL writer running in a separate thread, requesting that
+    the change be recorded in the WAL. The instance switches to work on the next
+    request until the write is acknowledged.
+
+5.  On success, a confirmation is sent to the client. On failure, a rollback
+    procedure is begun. During the rollback procedure, the transaction processor
+    rolls back all changes to the database which occurred after the first failed
+    change, from latest to oldest, up to the first failed change. All rolled back
+    requests are aborted with :errcode:`ER_WAL_IO <ER_WAL_IO>` error. No new
+    change is applied while rollback is in progress. When the rollback procedure
+    is finished, the server restarts the processing pipeline.
+
+One advantage of the described algorithm is that complete request pipelining is
+achieved, even for requests on the same value of the primary key. As a result,
+database performance doesn't degrade even if all requests refer to the same
+key in the same space.
+
+The transaction processor thread communicates with the WAL writer thread using
+asynchronous (yet reliable) messaging; the transaction processor thread, not
+being blocked on WAL tasks, continues to handle requests quickly even at high
+volumes of disk I/O. A response to a request is sent as soon as it is ready,
+even if there were earlier incomplete requests on the same connection. In
+particular, SELECT performance, even for SELECTs running on a connection packed
+with UPDATEs and DELETEs, remains unaffected by disk load.
+
+The WAL writer employs a number of durability modes, as defined in configuration
+variable :ref:`wal_mode <index-wal_mode>`. It is possible to turn the write-ahead
+log completely off, by setting
+:ref:`wal_mode <cfg_binary_logging_snapshots-wal_mode>` to *none*. Even
+without the write-ahead log it's still possible to take a persistent copy of the
+entire data set with the :ref:`box.snapshot() <box-snapshot>` request.
+
+An .xlog file always contains changes based on the primary key.
+Even if the client requested an update or delete using
+a secondary key, the record in the .xlog file will contain the primary key.
+
+..  _internals-snapshot:
+
+Snapshot file format
+--------------------
+
+The format of a snapshot .snap file is nearly the same as the format of a WAL .xlog file.
+However, the snapshot header differs: it contains the instance's global unique identifier
+and the snapshot file's position in history, relative to earlier snapshot files.
+Also, the content differs: an .xlog file may contain records for any data-change
+requests (inserts, updates, upserts, and deletes), a .snap file may only contain records
+of inserts to memtx spaces.
+
+Primarily, the .snap file's records are ordered by space id. Therefore the records of
+system spaces -- such as ``_schema``, ``_space``, ``_index``, ``_func``, ``_priv``
+and ``_cluster`` -- will be at the start of the .snap file, before the records of
+any spaces that were created by users.
+
+Secondarily, the .snap file's records are ordered by primary key within space id.

--- a/source/file_formats.rst
+++ b/source/file_formats.rst
@@ -10,9 +10,9 @@ Data persistence and the WAL file format
 
 To maintain data persistence, Tarantool writes each data change request (insert,
 update, delete, replace, upsert) into a write-ahead log (WAL) file in the
-:ref:`wal_dir <cfg_basic-wal_dir>` directory. A new WAL file is created for every
-:ref:`rows_per_wal <cfg_binary_logging_snapshots-rows_per_wal>` records, or for every
-:ref:`wal_max_size <cfg_binary_logging_snapshots-wal_max_size>` bytes.
+:ref:`wal_dir <community:cfg_basic-wal_dir>` directory. A new WAL file is created for every
+:ref:`rows_per_wal <community:cfg_binary_logging_snapshots-rows_per_wal>` records, or for every
+:ref:`wal_max_size <community:cfg_binary_logging_snapshots-wal_max_size>` bytes.
 Each data change request gets assigned a continuously growing 64-bit log sequence
 number. The name of the WAL file is based on the log sequence number of the first
 record in the file, plus an extension ``.xlog``.
@@ -23,7 +23,7 @@ each WAL record contains a header, some metadata, and then the data formatted
 according to `msgpack <https://en.wikipedia.org/wiki/MessagePack>`_ rules.
 For example, this is what the WAL file looks like after the first INSERT request
 ("s:insert({1})") for the sandbox database created in our
-:ref:`"Getting started" exercises <getting_started>`.
+:ref:`"Getting started" exercises <community:getting_started>`.
 On the left are the hexadecimal bytes that you would see with:
 
 ..  code-block:: console
@@ -100,11 +100,11 @@ particular, SELECT performance, even for SELECTs running on a connection packed
 with UPDATEs and DELETEs, remains unaffected by disk load.
 
 The WAL writer employs a number of durability modes, as defined in configuration
-variable :ref:`wal_mode <index-wal_mode>`. It is possible to turn the write-ahead
+variable :ref:`wal_mode <community:index-wal_mode>`. It is possible to turn the write-ahead
 log completely off, by setting
-:ref:`wal_mode <cfg_binary_logging_snapshots-wal_mode>` to *none*. Even
+:ref:`wal_mode <community:cfg_binary_logging_snapshots-wal_mode>` to *none*. Even
 without the write-ahead log it's still possible to take a persistent copy of the
-entire data set with the :ref:`box.snapshot() <box-snapshot>` request.
+entire data set with the :ref:`box.snapshot() <community:box-snapshot>` request.
 
 An .xlog file always contains changes based on the primary key.
 Even if the client requested an update or delete using

--- a/source/file_formats.rst
+++ b/source/file_formats.rst
@@ -82,7 +82,7 @@ REPLACE request as an example:
     procedure is begun. During the rollback procedure, the transaction processor
     rolls back all changes to the database which occurred after the first failed
     change, from latest to oldest, up to the first failed change. All rolled back
-    requests are aborted with :errcode:`ER_WAL_IO <ER_WAL_IO>` error. No new
+    requests are aborted with ``ER_WAL_IO <ER_WAL_IO>`` error. No new
     change is applied while rollback is in progress. When the rollback procedure
     is finished, the server restarts the processing pipeline.
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -11,3 +11,6 @@ Tarantool internals
    wal
    wal-fmt
    allocators
+   box_protocol
+   msgpack_extensions
+   file_formats

--- a/source/msgpack_extensions.rst
+++ b/source/msgpack_extensions.rst
@@ -102,7 +102,7 @@ The UUID type
 -------------
 
 The MessagePack EXT type ``MP_EXT`` together with the extension type
-``MP_UUID`` for values of the UUID type. Since version :doc:`2.4.1 </release/2.4.1>`.
+``MP_UUID`` for values of the UUID type. Since version :doc:`2.4.1 <community:release/2.4.1>`.
 
 MP_UUID is 2.
 
@@ -124,7 +124,7 @@ unsigned integers in the following order: time_low (4 bytes), time_mid
 (2 bytes), time_hi_and_version (2 bytes), clock_seq_hi_and_reserved (1
 byte), clock_seq_low (1 byte), node[0], ..., node[5] (1 byte each).
 
-Some of the functions in :ref:`Module uuid <uuid-module>` can produce values
+Some of the functions in :ref:`Module uuid <community:uuid-module>` can produce values
 which are compatible with the UUID data type.
 For example, after
 
@@ -147,7 +147,7 @@ a peek at the server response packet will show that it contains
 The ERROR type
 --------------
 
-Since version :doc:`2.4.1 </release/2.4.1>`, responses for errors have extra information
+Since version :doc:`2.4.1 <community:release/2.4.1>`, responses for errors have extra information
 following what was described in :ref:`Box protocol -- responses for errors
 <box_protocol-responses_error>`.
 This is a "compatible" enhancement, because clients that expect old-style
@@ -166,8 +166,8 @@ now IPROTO_ERROR is 0x52 and IPROTO_ERROR_24 is 0x31.
     ++=========================+============================+
                             MP_MAP
 
-The extra information, most of which is also in :doc:`error object
-</reference/reference_lua/box_error/new>` fields, is:
+The extra information, most of which is also in
+:doc:`error object <community:reference/reference_lua/box_error/new>` fields, is:
 
 ``MP_ERROR_TYPE`` (0x00) (MP_STR) Type that implies source, as in :samp:`{error_object}.base_type`, for example "ClientError".
 
@@ -182,7 +182,7 @@ The value here will be the same as in the ``IPROTO_ERROR_24`` value.
 Not to be confused with ``MP_ERROR_ERRCODE``.
 
 ``MP_ERROR_ERRCODE`` (0x05) (MP_UINT) Number of the error as defined in errcode.h, as in :samp:`{error_object}.code`,
-which can also be retrieved with the C function :ref:`box_error_code() <capi-box_error_code_code>`.
+which can also be retrieved with the C function :ref:`box_error_code() <community:capi-box_error_code_code>`.
 The value here will be the same as the lower part of the Response-Code-Indicator value.
 
 ``MP_ERROR_FIELDS`` (0x06) (MP_MAPs) Additional fields depending on error

--- a/source/msgpack_extensions.rst
+++ b/source/msgpack_extensions.rst
@@ -1,0 +1,231 @@
+..  _internals-msgpack_ext:
+
+..  _msgpack_ext-decimal:
+
+MessagePack extensions
+======================
+
+Tarantool uses predefined MessagePack extension types to represent some
+of the special values. Extension types include ``MP_DECIMAL``, ``MP_UUID``
+and ``MP_ERROR``. These types require special attention from the connector
+developers, as they must be treated separately from the default MessagePack
+types, and correctly mapped to programming language types.
+
+The DECIMAL type
+----------------
+
+The MessagePack EXT type ``MP_EXT`` together with the extension type
+``MP_DECIMAL`` is a header for values of the DECIMAL type.
+
+MP_DECIMAL is 1.
+
+`MessagePack spec <https://github.com/msgpack/msgpack/blob/master/spec.md>`_
+defines two kinds of types:
+
+*   ``fixext 1/2/4/8/16`` types have fixed length so the length is not encoded explicitly;
+*   ``ext 8/16/32`` types require the data length to be encoded.
+
+``MP_EXP`` + optional ``length`` imply using one of these types.
+
+The decimal MessagePack representation looks like this:
+
+..  code-block:: none
+
+    +--------+-------------------+------------+===============+
+    | MP_EXT | length (optional) | MP_DECIMAL | PackedDecimal |
+    +--------+-------------------+------------+===============+
+
+Here ``length`` is the length of ``PackedDecimal`` field, and it is of type
+``MP_UINT``, when encoded explicitly (i.e. when the type is ``ext 8/16/32``).
+
+``PackedDecimal`` has the following structure:
+
+..  code-block:: none
+
+     <--- length bytes -->
+    +-------+=============+
+    | scale |     BCD     |
+    +-------+=============+
+
+Here ``scale`` is either ``MP_INT`` or ``MP_UINT``. |br|
+``scale`` = number of digits after the decimal point
+
+``BCD`` is a sequence of bytes representing decimal digits of the encoded number
+(each byte has two decimal digits each encoded using 4-bit ``nibbles``),
+so ``byte >> 4`` is the first digit and ``byte & 0x0f`` is the second digit.
+The leftmost digit in the array is the most significant.
+The rightmost digit in the array is the least significant.
+
+The first byte of the ``BCD`` array contains the first digit of the number,
+represented as follows:
+
+..  code-block:: none
+
+    |  4 bits           |  4 bits           |
+       = 0x                = the 1st digit
+
+(The first ``nibble`` contains 0 if the decimal number has an even number of digits.)
+The last byte of the ``BCD`` array contains the last digit of the number and the
+final ``nibble``, represented as follows:
+
+..  code-block:: none
+
+    |  4 bits           |  4 bits           |
+       = the last digit    = nibble
+
+The final ``nibble`` represents the number's sign:
+
+* ``0x0a``, ``0x0c``, ``0x0e``, ``0x0f`` stand for plus,
+* ``0x0b`` and ``0x0d`` stand for minus.
+
+**Examples**
+
+The decimal ``-12.34`` will be encoded as ``0xd6,0x01,0x02,0x01,0x23,0x4d``:
+
+..  code-block:: none
+
+    |MP_EXT (fixext 4) | MP_DECIMAL | scale |  1   |  2,3 |  4 (minus) |
+    |       0xd6       |    0x01    | 0x02  | 0x01 | 0x23 | 0x4d       |
+
+The decimal 0.000000000000000000000000000000000010
+will be encoded as ``0xc7,0x03,0x01,0x24,0x01,0x0c``:
+
+..  code-block:: none
+
+    | MP_EXT (ext 8) | length | MP_DECIMAL | scale |  1   | 0 (plus) |
+    |      0xc7      |  0x03  |    0x01    | 0x24  | 0x01 | 0x0c     |
+
+
+..  _msgpack_ext-uuid:
+
+The UUID type
+-------------
+
+The MessagePack EXT type ``MP_EXT`` together with the extension type
+``MP_UUID`` for values of the UUID type. Since version :doc:`2.4.1 </release/2.4.1>`.
+
+MP_UUID is 2.
+
+The `MessagePack spec <https://github.com/msgpack/msgpack/blob/master/spec.md>`_
+defines ``d8`` to mean fixext with size 16, and a uuid's size is always 16.
+So the uuid MessagePack representation looks like this:
+
+..  code-block:: none
+
+    +--------+------------+-----------------+
+    | MP_EXT | MP_UUID    | UuidValue       |
+    | = d8   | = 2        | = 16-byte value |
+    +--------+------------+-----------------+
+
+
+The 16-byte value has 2 digits per byte.
+Typically it consists of 11 fields, which are encoded as big endian
+unsigned integers in the following order: time_low (4 bytes), time_mid
+(2 bytes), time_hi_and_version (2 bytes), clock_seq_hi_and_reserved (1
+byte), clock_seq_low (1 byte), node[0], ..., node[5] (1 byte each).
+
+Some of the functions in :ref:`Module uuid <uuid-module>` can produce values
+which are compatible with the UUID data type.
+For example, after
+
+..  code-block:: none
+
+    uuid = require('uuid')
+    box.schema.space.create('t')
+    box.space.t:create_index('i', {parts={1,'uuid'}})
+    box.space.t:insert{uuid.fromstr('f6423bdf-b49e-4913-b361-0740c9702e4b')}
+    box.space.t:select()
+
+a peek at the server response packet will show that it contains
+
+..  code-block:: none
+
+    d8 02 f6 42 3b df b4 9e 49 13 b3 61 07 40 c9 70 2e 4b
+
+..  _msgpack_ext-error:
+
+The ERROR type
+--------------
+
+Since version :doc:`2.4.1 </release/2.4.1>`, responses for errors have extra information
+following what was described in :ref:`Box protocol -- responses for errors
+<box_protocol-responses_error>`.
+This is a "compatible" enhancement, because clients that expect old-style
+server responses should ignore map components that they do not recognize.
+Notice, however, that there has been a renaming of a constant:
+formerly IPROTO_ERROR in ./box/iproto_constants.h was 0x31,
+now IPROTO_ERROR is 0x52 and IPROTO_ERROR_24 is 0x31.
+
+..  code-block:: none
+
+    ++=========================+============================+
+    ||                         |                            |
+    ||   0x31: IPROTO_ERROR_24 |   0x52: IPROTO_ERROR       |
+    || MP_INT: MP_STRING       | MP_MAP: extra information  |
+    ||                         |                            |
+    ++=========================+============================+
+                            MP_MAP
+
+The extra information, most of which is also in :doc:`error object
+</reference/reference_lua/box_error/new>` fields, is:
+
+``MP_ERROR_TYPE`` (0x00) (MP_STR) Type that implies source, as in :samp:`{error_object}.base_type`, for example "ClientError".
+
+``MP_ERROR_FILE`` (0x01) (MP_STR)  Source code file where error was caught, as in :samp:`{error_object}.trace`.
+
+``MP_ERROR_LINE`` (0x02) (MP_UINT) Line number in source code file, as in :samp:`{error_object}.trace`.
+
+``MP_ERROR_MESSAGE`` (0x03) (MP_STR) Text of reason, as in :samp:`{error_object}.message`.
+The value here will be the same as in the ``IPROTO_ERROR_24`` value.
+
+``MP_ERROR_ERRNO`` (0x04) (MP_UINT) Ordinal number of the error, as in :samp:`{error_object}.errno`.
+Not to be confused with ``MP_ERROR_ERRCODE``.
+
+``MP_ERROR_ERRCODE`` (0x05) (MP_UINT) Number of the error as defined in errcode.h, as in :samp:`{error_object}.code`,
+which can also be retrieved with the C function :ref:`box_error_code() <capi-box_error_code_code>`.
+The value here will be the same as the lower part of the Response-Code-Indicator value.
+
+``MP_ERROR_FIELDS`` (0x06) (MP_MAPs) Additional fields depending on error
+type. For example, if ``MP_ERROR_TYPE`` is "AccessDeniedError", then ``MP_ERROR_FIELDS``
+will include "object_type", "object_name", "access_type". This field will be
+omitted from the response body if there are no additional fields available.
+
+Client and connector programmers should ensure that unknown map keys are ignored,
+and should check for addition of new keys in the Tarantool
+source code file where error object creation is defined.
+In version 2.4.1 the name of this source code file is mp_error.cc.
+
+For example, in version 2.4.1 or later, if we try to create a duplicate space with |br|
+``conn:eval([[box.schema.space.create('_space');]])`` |br|
+the server response will look like this:
+
+..  code-block:: none
+
+    ce 00 00 00 88                  MP_UINT = HEADER + BODY SIZE
+    83                              MP_MAP, size 3 (i.e. 3 items in header)
+      00                              Response-Code-Indicator
+      ce 00 00 80 0a                  MP_UINT = hexadecimal 800a
+      01                              IPROTO_SYNC
+      cf 00 00 00 00 00 00 00 05      MP_UINT = sync value
+      05                              IPROTO_SCHEMA_VERSION
+      ce 00 00 00 4e                  MP_UINT = schema version value
+    82                              MP_MAP, size 2
+      31                              IPROTO_ERROR_24
+      bd 53 70 61 63 etc.             MP_STR = "Space '_space' already exists"
+      52                              IPROTO_ERROR
+      81                              MP_MAP, size 1
+        00                              MP_ERROR_STACK
+        91                              MP_ARRAY, size 1
+          86                              MP_MAP, size 6
+            00                              MP_ERROR_TYPE
+            ab 43 6c 69 65 6e 74 etc.       MP_STR = "ClientError"
+            02                              MP_ERROR_LINE
+            cd                              MP_UINT = line number
+            01                              MP_ERROR_FILE
+            aa 01 b6 62 75 69 6c etc.       MP_STR "builtin/box/schema.lua"
+            03                              MP_ERROR_MESSAGE
+            bd 53 70 61 63 65 20 etc.       MP_STR = Space.'_space'.already.exists"
+            04                              MP_ERROR_ERRNO
+            00                              MP_UINT = error number
+            05                              MP_ERROR_ERRCODE
+            0a                              MP_UINT = eror code ER_SPACE_EXISTS

--- a/source/prolog.rst
+++ b/source/prolog.rst
@@ -1,0 +1,38 @@
+
+.. role:: codenormal
+   :class: ccode
+
+.. role:: codebold
+   :class: ccodeb
+
+.. role:: codeitalic
+   :class: ccodei
+
+.. role:: codebolditalic
+   :class: ccodebi
+
+.. role:: codegreen
+   :class: ccodegreen
+
+.. role:: codered
+   :class: ccodered
+
+.. role:: codeblue
+   :class: ccodeblue
+
+.. role:: currentversion
+   :class: current-version
+
+.. role:: specialtext
+   :class: special-text
+
+.. |nbsp| unicode:: 0xA0
+
+.. |space| unicode:: U+0020
+
+.. |br| raw:: html
+
+    <br />
+
+.. |iproto_version| replace:: 3
+

--- a/source/toctree.rst
+++ b/source/toctree.rst
@@ -12,3 +12,6 @@
    wal
    wal-fmt
    allocators
+   box_protocol
+   msgpack_extensions
+   file_formats


### PR DESCRIPTION
Add the following docs:
- https://www.tarantool.io/en/doc/latest/dev_guide/internals/file_formats/
- https://www.tarantool.io/en/doc/latest/dev_guide/internals/msgpack_extensions/
- https://www.tarantool.io/en/doc/latest/dev_guide/internals/box_protocol/

Do not delete these documents from tarantool/doc yet. We will do it when the doc domain is interlinked with the tarantool-internals domain just right.