### PR TITLE
ci: cancel outdated workflow runs

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -2,6 +2,28 @@ name: Deploy branch
 
 on:
   pull_request:
+
+# Cancel workflow runs on PRs when the PR is updated with a newer commit.
+# Such runs will have a concurrency group named
+# `{github.workflow}-{github.ref}`,
+# for example,
+# `deploy-branch/refs/add-concurrency`.
+#
+# Runs on the `master` branch and tags will never be canceled,
+# due to having a unique group name
+# `{github.run_id}-{github.run_attempt}`,
+# for example,
+# `3477882280-1`.
+concurrency:
+  group: ${{
+    (
+    github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/tags/')
+    ) &&
+    format('{0}-{1}', github.run_id, github.run_attempt) ||
+    format('{0}-{1}', github.workflow, github.ref) }}
+  cancel-in-progress: true
+
 jobs:
   deploy-branch:
     runs-on: ['self-hosted', 'Linux', 'flavor-8-16']


### PR DESCRIPTION
Cancel workflow runs on PRs when the PR is updated with a newer commit. Such runs will have a concurrency group named
`{github.workflow}-{github.ref}`,
for example,
`deploy-branch/refs/add-concurrency`.

Runs on branches `master`, `tt`, and also tags, will never be canceled, due to having a unique group name
`{github.run_id}-{github.run_attempt}`,
for example,
`3477882280-1`.

Part of tarantool/doc#3234

Concurrency:

- [x] concurrency using stable branches from this repo
- [x] commits start with `ci:`
- [x] concurrency commit goes first in the branch
- [x] concurrency commit has the same text as in the action
- [x] concurrency commit links to https://github.com/tarantool/doc/issues/3234
- [x] concurrency workflow checked https://github.com/tarantool/tarantool-internals/actions/runs/3538597649
